### PR TITLE
feat: support -h as shortcut for --help

### DIFF
--- a/comfyui_skills_cli/main.py
+++ b/comfyui_skills_cli/main.py
@@ -11,6 +11,7 @@ app = typer.Typer(
     help="ComfyUI Skill CLI — Agent-friendly workflow management",
     no_args_is_help=True,
     rich_markup_mode="rich",
+    context_settings={"help_option_names": ["-h", "--help"]},
 )
 
 


### PR DESCRIPTION
## Summary
- 在 Typer app 的 `context_settings` 中添加 `help_option_names: ["-h", "--help"]`
- 用户可以用 `comfyui-skill -h` 代替 `comfyui-skill --help`

## Test plan
- [x] `comfyui-skill -h` 正常输出帮助信息