### PR TITLE
feat: add --type video preset and fix media type inference

### DIFF
--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -257,9 +257,24 @@ def _inject_params(
 _MEDIA_KEYS: dict[str, str] = {
     "images": "image",
     "audio": "audio",
-    "gifs": "image",
-    "video": "video",
 }
+
+_VIDEO_EXTENSIONS = {".mp4", ".webm", ".mov", ".avi", ".mkv"}
+_AUDIO_EXTENSIONS = {".mp3", ".wav", ".flac", ".ogg", ".opus", ".aac"}
+
+
+def _infer_media_type(filename: str, key_hint: str) -> str:
+    """Infer accurate media type from file extension, falling back to the
+    history key hint.  ComfyUI's SaveVideo uses the ``"images"`` key for
+    video files, so the key alone is not reliable."""
+    ext = os.path.splitext(filename)[1].lower()
+    if ext in _VIDEO_EXTENSIONS:
+        return "video"
+    if ext in _AUDIO_EXTENSIONS:
+        return "audio"
+    if key_hint == "audio":
+        return "audio"
+    return "image"
 
 
 def _collect_outputs(outputs: dict[str, Any]) -> list[dict[str, str]]:
@@ -267,13 +282,14 @@ def _collect_outputs(outputs: dict[str, Any]) -> list[dict[str, str]]:
     for node_output in outputs.values():
         if not isinstance(node_output, dict):
             continue
-        for key, media_type in _MEDIA_KEYS.items():
+        for key, key_hint in _MEDIA_KEYS.items():
             for item in node_output.get(key, []):
+                filename = item.get("filename", "")
                 collected.append({
-                    "filename": item.get("filename", ""),
+                    "filename": filename,
                     "subfolder": item.get("subfolder", ""),
                     "type": item.get("type", "output"),
-                    "media_type": media_type,
+                    "media_type": _infer_media_type(filename, key_hint),
                 })
     return collected
 

--- a/comfyui_skills_cli/commands/workflow.py
+++ b/comfyui_skills_cli/commands/workflow.py
@@ -69,6 +69,19 @@ _MEDIA_TYPE_FIELDS: dict[str, dict[str, dict[str, Any]]] = {
         "cfg_scale": {"exposed": True, "required": False, "description": "Classifier-free guidance scale"},
         "temperature": {"exposed": True, "required": False, "description": "Sampling temperature"},
     },
+    "video": {
+        "noise_seed": {"exposed": True, "required": False, "description": "Random seed"},
+        "cfg": {"exposed": True, "required": False, "description": "Classifier-free guidance scale"},
+        "value": {"exposed": True, "required": False, "description": "Node parameter value"},
+        "format": {"exposed": True, "required": False, "description": "Output format"},
+        "codec": {"exposed": True, "required": False, "description": "Video codec"},
+        "strength": {"exposed": True, "required": False, "description": "Effect strength"},
+        "strength_model": {"exposed": True, "required": False, "description": "LoRA model strength"},
+        "strength_clip": {"exposed": True, "required": False, "description": "LoRA CLIP strength"},
+        "img_compression": {"exposed": True, "required": False, "description": "Image compression level"},
+        "longer_edge": {"exposed": True, "required": False, "description": "Resolution by longer edge"},
+        "max_length": {"exposed": True, "required": False, "description": "Max prompt token length"},
+    },
 }
 
 _LOAD_IMAGE_CLASSES = {"LoadImage", "LoadImageMask"}
@@ -383,7 +396,7 @@ def workflow_import(
     ctx: typer.Context,
     json_path: str = typer.Argument(None, help="Path to workflow JSON file (omit when using --from-server)"),
     name: str = typer.Option("", "--name", "-n", help="Workflow ID (default: derived from filename)"),
-    media_type: str = typer.Option("image", "--type", "-t", help="Media type preset for parameter detection: image (default), audio"),
+    media_type: str = typer.Option("image", "--type", "-t", help="Media type preset for parameter detection: image (default), audio, video"),
     from_server: bool = typer.Option(False, "--from-server", help="Import from ComfyUI server userdata"),
     preview: bool = typer.Option(False, "--preview", help="Preview only, don't import"),
     check_deps: bool = typer.Option(False, "--check-deps", help="Check dependencies after import"),
@@ -393,7 +406,9 @@ def workflow_import(
     Use --type to select a parameter detection preset. The default (image)
     detects generic fields like seed, steps, and prompt. Use --type audio
     to also detect audio-specific fields like tags, lyrics, bpm, duration,
-    keyscale, language, cfg_scale, and temperature.
+    keyscale, language, cfg_scale, and temperature. Use --type video to
+    detect video-specific fields like noise_seed, cfg, format, codec,
+    strength, and Primitive node values (prompt, width, height, etc.).
     """
     base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
     config = load_config(base_dir)


### PR DESCRIPTION
## Summary

- **Add `--type video` preset** to `workflow import`: detects video-specific parameters (`noise_seed`, `cfg`, `value`, `format`, `codec`, `strength`, `strength_model`, `strength_clip`, `img_compression`, `longer_edge`, `max_length`) from Primitive and video-related nodes. Follows the same `_MEDIA_TYPE_FIELDS` pattern approved in PR #3 for `--type audio`.
- **Fix `media_type` misreporting for video files**: ComfyUI's `SaveVideo`/`PreviewVideo` nodes report video output under the `"images"` history key (with an `animated` flag), causing all video files to be reported as `media_type: "image"`. New `_infer_media_type()` uses file extension (`.mp4`, `.webm`, `.mp3`, `.wav`, etc.) for accurate classification.
- **Remove dead `"gifs"` and `"video"` entries from `_MEDIA_KEYS`**: ComfyUI's source (`comfy_api/latest/_ui.py`) confirms only `"images"` and `"audio"` keys are ever populated in `/history` output. These entries never matched anything.

## Changes

| File | Change |
|------|--------|
| `commands/run.py` | Add `_infer_media_type()`, `_VIDEO_EXTENSIONS`, `_AUDIO_EXTENSIONS`; remove dead `"gifs"`/`"video"` from `_MEDIA_KEYS`; update `_collect_outputs()` to use extension-based inference |
| `commands/workflow.py` | Add `"video"` preset to `_MEDIA_TYPE_FIELDS` (11 fields); update `--type` help text |

## Test plan

- [x] Import video workflow with `--type video`: confirms 25 parameters detected (vs 7 without)
- [x] Import audio workflow with `--type audio`: confirms 14 parameters (unchanged from PR #3)
- [x] Import image workflow (default): confirms 7 parameters (unchanged)
- [x] Run video workflow: output correctly reports `media_type: "video"` (was `"image"` before)
- [x] Run audio workflow: output correctly reports `media_type: "audio"`
- [x] Run image workflow: output correctly reports `media_type: "image"`
- [x] Clean-slate test: uninstall CLI, delete all data, reinstall, reimport all 3 workflows — auto-generated schemas are byte-identical to previously hand-curated versions