### PR TITLE
docs: redesign README to match main repo style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,63 @@
-# ComfyUI Skill CLI
-
 <div align="center">
-<pre>
-+--------------------------------------------------+
-|                                                  |
-|      ____                 __       _   _ ___     |
-|     / ___|___  _ __ ___  / _|_   _| | | |_ _|    |
-|    | |   / _ \| '_ ` _ \| |_| | | | | | || |     |
-|    | |__| (_) | | | | | |  _| |_| | |_| || |     |
-|     \____\___/|_| |_| |_|_|  \__, |\___/|___|    |
-|                              |___/               |
-|        ____  _    _ _ _    ____ _     ___        |
-|       / ___|| | _(_) | |  / ___| |   |_ _|       |
-|       \___ \| |/ / | | | | |   | |    | |        |
-|        ___) |   <| | | | | |___| |___ | |        |
-|       |____/|_|\_\_|_|_|  \____|_____|___|       |
-|                                                  |
-+--------------------------------------------------+
-</pre>
+
+  <h1>ComfyUI Skill CLI</h1>
+
+  <p><strong>Agent-friendly command-line tool for managing and executing ComfyUI workflow skills.</strong></p>
+
+  <p>
+    Any AI agent that can run shell commands (Claude Code, Codex, OpenClaw, etc.) can use ComfyUI through this CLI.
+  </p>
+
+  <p>
+    <a href="https://pypi.org/project/comfyui-skill-cli/"><img src="https://img.shields.io/pypi/v/comfyui-skill-cli?style=flat&color=4F46E5&logo=pypi&logoColor=white" alt="PyPI"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skill_CLI/blob/main/LICENSE"><img src="https://img.shields.io/github/license/HuangYuChuh/ComfyUI_Skill_CLI?style=flat&color=10B981" alt="License"></a>
+    <a href="https://www.python.org/"><img src="https://img.shields.io/static/v1?label=Python&message=3.10%2B&color=3B82F6&style=flat&logo=python&logoColor=white" alt="Python 3.10+"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skill_CLI/stargazers"><img src="https://img.shields.io/github/stars/HuangYuChuh/ComfyUI_Skill_CLI?style=flat&color=EAB308&logo=github" alt="GitHub stars"></a>
+  </p>
+
+  <p>
+    <a href="#install">Install</a> ·
+    <a href="#quick-start">Quick Start</a> ·
+    <a href="#commands">Commands</a> ·
+    <a href="#for-ai-agents">For AI Agents</a>
+  </p>
+
+  <p>
+    <strong>English</strong> ·
+    <a href="./README.zh.md">简体中文</a>
+  </p>
+
 </div>
 
-[中文版](./README.zh.md) | [English](./README.md)
-
-Agent-friendly command-line tool for managing and executing [ComfyUI](https://github.com/comfyanonymous/ComfyUI) workflow skills. Any AI agent that can run shell commands (Claude, Codex, OpenClaw, etc.) can use ComfyUI through this CLI.
-
-[Install](#install) · [Quick Start](#quick-start) · [Commands](#commands) · [For AI Agents](#for-ai-agents)
+---
 
 ## Why comfyui-skill?
 
-- **Agent-native** — structured JSON output, pipe-friendly, designed for AI agents to call
-- **Zero config** — reads `config.json` and `data/` from the current directory, no setup needed
-- **Full lifecycle** — discover, import, execute, manage workflows and dependencies in one tool
-- **Multi-server** — manage multiple ComfyUI instances, route jobs to different hardware
+| Capability | Why it matters |
+|------------|----------------|
+| **Agent-native** | Structured JSON output, pipe-friendly, designed for AI agents to call |
+| **Zero config** | Reads `config.json` and `data/` from the current directory, no setup needed |
+| **Full lifecycle** | Discover, import, execute, cancel, manage workflows and dependencies in one tool |
+| **Multi-server** | Manage multiple ComfyUI instances, route jobs to different hardware |
+| **Error guidance** | Common failures (OOM, unauthorized, missing models) return actionable hints |
 
+<a id="install"></a>
 ## Install
 
 ```bash
 pipx install comfyui-skill-cli
+```
+
+Or with pip:
+
+```bash
+pip install comfyui-skill-cli
+```
+
+### Update
+
+```bash
+pipx upgrade comfyui-skill-cli
 ```
 
 ### Development Mode
@@ -47,14 +68,7 @@ cd ComfyUI_Skill_CLI
 pipx install -e .
 ```
 
-The `-e` flag (editable) links directly to your local source — any code change is reflected instantly.
-
-### Update
-
-```bash
-pipx upgrade comfyui-skill-cli
-```
-
+<a id="quick-start"></a>
 ## Quick Start
 
 ```bash
@@ -75,21 +89,15 @@ Every command supports `--json` for structured output.
 
 ## ID Convention
 
-This CLI uses two types of IDs:
-
-| Notation | Meaning | Example |
-|----------|---------|---------|
-| `<workflow_id>` | Workflow identifier, format: `server_id/workflow_name` | `local/txt2img` |
-| `<server_id>` | Server identifier | `local`, `remote-a100` |
-
-When `<workflow_id>` omits the server prefix, the default server is used:
+Workflows are addressed as `<server_id>/<workflow_id>`:
 
 ```bash
 comfyui-skill run local/txt2img          # explicit server
 comfyui-skill run txt2img                # uses default server
-comfyui-skill run txt2img -s my_server   # override server via flag
+comfyui-skill run txt2img -s my_server   # override with --server flag
 ```
 
+<a id="commands"></a>
 ## Commands
 
 ### Workflow Discovery & Execution
@@ -97,105 +105,126 @@ comfyui-skill run txt2img -s my_server   # override server via flag
 | Command | Description |
 |---------|-------------|
 | `comfyui-skill list` | List all available workflows with parameters |
-| `comfyui-skill info <workflow_id>` | Show workflow details and parameter schema |
-| `comfyui-skill run <workflow_id> --args '{...}'` | Execute a workflow (blocking, returns images) |
-| `comfyui-skill submit <workflow_id> --args '{...}'` | Submit a workflow (non-blocking, returns prompt_id) |
+| `comfyui-skill info <id>` | Show workflow details and parameter schema |
+| `comfyui-skill run <id> --args '{...}'` | Execute a workflow (blocking) |
+| `comfyui-skill submit <id> --args '{...}'` | Submit a workflow (non-blocking) |
 | `comfyui-skill status <prompt_id>` | Check execution status and download results |
-| `comfyui-skill upload <image_path>` | Upload image to ComfyUI for use in workflows |
+| `comfyui-skill cancel <prompt_id>` | Cancel a running or queued job |
+| `comfyui-skill upload <file>` | Upload a file to ComfyUI for use in workflows |
+| `comfyui-skill upload --from-output <prompt_id>` | Chain a previous run's output as input for the next workflow |
+
+### Queue & Resource Management
+
+| Command | Description |
+|---------|-------------|
+| `comfyui-skill queue list` | Show running and pending jobs |
+| `comfyui-skill queue clear` | Clear all pending jobs |
+| `comfyui-skill queue delete <prompt_id>...` | Remove specific jobs from queue |
+| `comfyui-skill free` | Release GPU memory and unload models |
+| `comfyui-skill free --models` | Unload models only |
+| `comfyui-skill free --memory` | Free cached memory only |
+
+### Model Discovery
+
+| Command | Description |
+|---------|-------------|
+| `comfyui-skill models list` | List all available model folders |
+| `comfyui-skill models list <folder>` | List models in a specific folder (e.g., `checkpoints`, `loras`) |
 
 ### Workflow Management
 
 | Command | Description |
 |---------|-------------|
-| `comfyui-skill workflow import <json_path>` | Import workflow from local JSON (auto-detect format, auto-convert, auto-generate schema) |
-| `comfyui-skill workflow import --from-server` | Import workflows from ComfyUI server userdata |
-| `comfyui-skill workflow enable <workflow_id>` | Enable a workflow |
-| `comfyui-skill workflow disable <workflow_id>` | Disable a workflow |
-| `comfyui-skill workflow delete <workflow_id>` | Delete a workflow |
+| `comfyui-skill workflow import <path>` | Import workflow (auto-detect format, auto-generate schema) |
+| `comfyui-skill workflow import --from-server` | Import from ComfyUI server userdata |
+| `comfyui-skill workflow enable <id>` | Enable a workflow |
+| `comfyui-skill workflow disable <id>` | Disable a workflow |
+| `comfyui-skill workflow delete <id>` | Delete a workflow |
 
 ### Server Management
 
 | Command | Description |
 |---------|-------------|
 | `comfyui-skill server list` | List all configured servers |
-| `comfyui-skill server status [<server_id>]` | Check if ComfyUI server is online |
-| `comfyui-skill server add --id <server_id> --url <url>` | Add a new server |
-| `comfyui-skill server enable <server_id>` | Enable a server |
-| `comfyui-skill server disable <server_id>` | Disable a server |
-| `comfyui-skill server remove <server_id>` | Remove a server |
+| `comfyui-skill server status` | Check if ComfyUI server is online |
+| `comfyui-skill server add --id <id> --url <url>` | Add a new server |
+| `comfyui-skill server enable/disable <id>` | Toggle server availability |
+| `comfyui-skill server remove <id>` | Remove a server |
 
 ### Dependency Management
 
 | Command | Description |
 |---------|-------------|
-| `comfyui-skill deps check <workflow_id>` | Check missing custom nodes and models |
-| `comfyui-skill deps install <workflow_id> --repos '[...]'` | Install missing custom nodes via Manager |
-| `comfyui-skill deps install <workflow_id> --models` | Install missing models via Manager |
-| `comfyui-skill deps install <workflow_id> --all` | Auto-detect and install all missing deps |
+| `comfyui-skill deps check <id>` | Check missing custom nodes and models |
+| `comfyui-skill deps install <id> --all` | Auto-detect and install all missing deps |
+| `comfyui-skill deps install <id> --repos '[...]'` | Install specific custom nodes |
+| `comfyui-skill deps install <id> --models` | Install missing models via Manager |
 
-### Configuration Transfer
+### Configuration & History
 
 | Command | Description |
 |---------|-------------|
 | `comfyui-skill config export --output <path>` | Export config and workflows as bundle |
-| `comfyui-skill config import <path>` | Import config bundle (supports --dry-run) |
-
-### Execution History
-
-| Command | Description |
-|---------|-------------|
-| `comfyui-skill history list <workflow_id>` | List execution history for a workflow |
-| `comfyui-skill history show <workflow_id> <run_id>` | Show details of a specific run |
+| `comfyui-skill config import <path>` | Import config bundle (supports `--dry-run`) |
+| `comfyui-skill history list <id>` | List execution history |
+| `comfyui-skill history show <id> <run_id>` | Show details of a specific run |
 
 ### Global Options
 
 | Option | Description |
 |--------|-------------|
 | `--json, -j` | Force JSON output |
-| `--server, -s <server_id>` | Specify server ID |
-| `--dir, -d <path>` | Specify data directory (default: current directory) |
+| `--output-format` | Output format: `text`, `json`, `stream-json` |
+| `--server, -s` | Specify server ID |
+| `--dir, -d` | Specify data directory (default: current directory) |
 | `--verbose, -v` | Verbose output |
+| `--no-update-check` | Skip automatic CLI update check |
 
 ### Output Modes
 
-- **TTY** → Rich tables and progress bars (human-friendly)
-- **Pipe / `--json`** → Structured JSON (agent-friendly)
-- **Errors** → Always stderr
+| Mode | When | Format |
+|------|------|--------|
+| Text | TTY terminal | Rich tables and progress bars |
+| JSON | Pipe or `--json` | Single JSON result |
+| Stream JSON | `--output-format stream-json` | NDJSON events in real time |
+| Errors | Always | stderr |
 
+<a id="for-ai-agents"></a>
 ## For AI Agents
 
-This CLI is designed to be called from `SKILL.md` definitions:
+This CLI is designed to be called from `SKILL.md` definitions. A typical agent workflow:
 
 ```bash
-# Typical agent workflow
-comfyui-skill server status --json                        # 1. verify server is online
-comfyui-skill list --json                                 # 2. discover available workflows
-comfyui-skill info local/txt2img --json                   # 3. check required parameters
-comfyui-skill run local/txt2img --args '{...}' --json     # 4. execute
+comfyui-skill server status --json                    # 1. verify server
+comfyui-skill list --json                             # 2. discover workflows
+comfyui-skill info local/txt2img --json               # 3. check parameters
+comfyui-skill run local/txt2img --args '{...}' --json # 4. execute
 ```
 
-### Import a new workflow
+### Workflow chaining (multi-step pipelines)
 
 ```bash
-# Import and check dependencies in one step
-comfyui-skill workflow import ./workflow.json --check-deps --json
+# Run first workflow
+comfyui-skill run local/txt2img --args '{"prompt": "a cat"}' --json
 
-# Install missing dependencies
+# Chain output into next workflow
+comfyui-skill upload --from-output <prompt_id> --json
+comfyui-skill run local/upscale --args '{"image": "<uploaded_name>"}' --json
+```
+
+### Import and validate
+
+```bash
+comfyui-skill workflow import ./workflow.json --check-deps --json
 comfyui-skill deps install local/my-workflow --all --json
 ```
 
-## Exit Codes
+## Contributing
 
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | General error |
-| 2 | Invalid arguments |
-| 3 | Server connection failed |
-| 4 | Resource not found |
-| 5 | Execution failed |
-| 6 | Timeout |
+Contributions are welcome! Please read the [Contributing Guide](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/CONTRIBUTING.md) in the main repository for design principles and PR workflow.
 
-## Compatibility
+## Resources
 
-Built with [Typer](https://typer.tiangolo.com/), the same framework as [comfy-cli](https://github.com/Comfy-Org/comfy-cli). Designed to be integrated as a `comfy skills` subcommand in the future.
+- [ComfyUI Skills OpenClaw](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw) — Main skills repository
+- [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — The backend this CLI orchestrates
+- [Typer](https://typer.tiangolo.com/) — CLI framework used by this project

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,37 +1,45 @@
-# ComfyUI Skill CLI
-
 <div align="center">
-<pre>
-+--------------------------------------------------+
-|                                                  |
-|      ____                 __       _   _ ___     |
-|     / ___|___  _ __ ___  / _|_   _| | | |_ _|    |
-|    | |   / _ \| '_ ` _ \| |_| | | | | | || |     |
-|    | |__| (_) | | | | | |  _| |_| | |_| || |     |
-|     \____\___/|_| |_| |_|_|  \__, |\___/|___|    |
-|                              |___/               |
-|        ____  _    _ _ _    ____ _     ___        |
-|       / ___|| | _(_) | |  / ___| |   |_ _|       |
-|       \___ \| |/ / | | | | |   | |    | |        |
-|        ___) |   <| | | | | |___| |___ | |        |
-|       |____/|_|\_\_|_|_|  \____|_____|___|       |
-|                                                  |
-+--------------------------------------------------+
-</pre>
+
+  <h1>ComfyUI Skill CLI</h1>
+
+  <p><strong>面向 AI Agent 的 ComfyUI 工作流命令行工具</strong></p>
+
+  <p>
+    任何能执行 Shell 命令的 AI Agent（Claude Code、Codex、OpenClaw 等）都可以通过这个 CLI 调用 ComfyUI。
+  </p>
+
+  <p>
+    <a href="https://pypi.org/project/comfyui-skill-cli/"><img src="https://img.shields.io/pypi/v/comfyui-skill-cli?style=flat&color=4F46E5&logo=pypi&logoColor=white" alt="PyPI"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skill_CLI/blob/main/LICENSE"><img src="https://img.shields.io/github/license/HuangYuChuh/ComfyUI_Skill_CLI?style=flat&color=10B981" alt="License"></a>
+    <a href="https://www.python.org/"><img src="https://img.shields.io/static/v1?label=Python&message=3.10%2B&color=3B82F6&style=flat&logo=python&logoColor=white" alt="Python 3.10+"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skill_CLI/stargazers"><img src="https://img.shields.io/github/stars/HuangYuChuh/ComfyUI_Skill_CLI?style=flat&color=EAB308&logo=github" alt="GitHub stars"></a>
+  </p>
+
+  <p>
+    <a href="#安装">安装</a> ·
+    <a href="#快速开始">快速开始</a> ·
+    <a href="#命令">命令</a> ·
+    <a href="#ai-agent-使用">AI Agent 使用</a>
+  </p>
+
+  <p>
+    <a href="./README.md">English</a> ·
+    <strong>简体中文</strong>
+  </p>
+
 </div>
 
-[中文版](./README.zh.md) | [English](./README.md)
-
-面向 AI Agent 的 ComfyUI 工作流命令行工具。任何能执行 Shell 命令的 AI Agent（Claude、Codex、OpenClaw 等）都可以通过这个 CLI 调用 ComfyUI。
-
-[安装](#安装) · [快速开始](#快速开始) · [命令](#命令) · [AI Agent 使用](#ai-agent-使用)
+---
 
 ## 为什么选 comfyui-skill？
 
-- **为 Agent 原生设计** — 结构化 JSON 输出，管道友好，专为 AI Agent 调用优化
-- **零配置** — 从当前目录读取 `config.json` 和 `data/`，开箱即用
-- **全生命周期管理** — 发现、导入、执行、管理工作流和依赖，一个工具搞定
-- **多服务器** — 同时管理多台 ComfyUI 实例，按需分发任务到不同算力
+| 能力 | 价值 |
+|------|------|
+| **Agent 原生** | 结构化 JSON 输出，管道友好，专为 AI Agent 调用优化 |
+| **零配置** | 从当前目录读取 `config.json` 和 `data/`，开箱即用 |
+| **全生命周期** | 发现、导入、执行、取消、管理工作流和依赖，一个工具搞定 |
+| **多服务器** | 同时管理多台 ComfyUI 实例，按需分发任务到不同算力 |
+| **错误引导** | 常见失败（显存不足、未授权、模型缺失）自动返回可操作的提示 |
 
 ## 安装
 
@@ -39,22 +47,24 @@
 pipx install comfyui-skill-cli
 ```
 
-### 开发模式
-
-如果你想修改 CLI 源码并让改动立刻生效：
+或用 pip：
 
 ```bash
-git clone https://github.com/HuangYuChuh/ComfyUI_Skill_CLI.git
-cd ComfyUI_Skill_CLI
-pipx install -e .
+pip install comfyui-skill-cli
 ```
-
-`-e`（editable）会直接链接到本地源码，改完代码无需重新安装。
 
 ### 更新
 
 ```bash
 pipx upgrade comfyui-skill-cli
+```
+
+### 开发模式
+
+```bash
+git clone https://github.com/HuangYuChuh/ComfyUI_Skill_CLI.git
+cd ComfyUI_Skill_CLI
+pipx install -e .
 ```
 
 ## 快速开始
@@ -66,7 +76,7 @@ cd /path/to/your-skills-project
 # 2. 检查服务器状态
 comfyui-skill server status
 
-# 3. 查看可用的工作流
+# 3. 查看可用工作流
 comfyui-skill list
 
 # 4. 执行工作流
@@ -77,14 +87,7 @@ comfyui-skill run local/txt2img --args '{"prompt": "a white cat"}'
 
 ## ID 约定
 
-CLI 中有两种 ID，请注意区分：
-
-| 标记 | 含义 | 示例 |
-|------|------|------|
-| `<workflow_id>` | 工作流标识，格式为 `服务器ID/工作流名称` | `local/txt2img` |
-| `<server_id>` | 服务器标识 | `local`、`remote-a100` |
-
-当 `<workflow_id>` 省略服务器前缀时，自动使用默认服务器：
+工作流使用 `<server_id>/<workflow_id>` 格式：
 
 ```bash
 comfyui-skill run local/txt2img          # 指定服务器
@@ -99,105 +102,125 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | 命令 | 说明 |
 |------|------|
 | `comfyui-skill list` | 列出所有可用工作流及参数 |
-| `comfyui-skill info <workflow_id>` | 查看工作流详情和参数 schema |
-| `comfyui-skill run <workflow_id> --args '{...}'` | 执行工作流（阻塞，等待完成返回图片路径） |
-| `comfyui-skill submit <workflow_id> --args '{...}'` | 提交工作流（非阻塞，立即返回 prompt_id） |
-| `comfyui-skill status <prompt_id>` | 查询执行状态，完成后下载结果 |
-| `comfyui-skill upload <image_path>` | 上传图片到 ComfyUI 供工作流使用 |
+| `comfyui-skill info <id>` | 查看工作流详情和参数 schema |
+| `comfyui-skill run <id> --args '{...}'` | 执行工作流（阻塞） |
+| `comfyui-skill submit <id> --args '{...}'` | 提交工作流（非阻塞） |
+| `comfyui-skill status <prompt_id>` | 查询执行状态 |
+| `comfyui-skill cancel <prompt_id>` | 取消运行中或排队中的任务 |
+| `comfyui-skill upload <file>` | 上传文件到 ComfyUI 供工作流使用 |
+| `comfyui-skill upload --from-output <prompt_id>` | 将上次运行的输出作为下一个工作流的输入 |
+
+### 队列与资源管理
+
+| 命令 | 说明 |
+|------|------|
+| `comfyui-skill queue list` | 查看运行中和排队中的任务 |
+| `comfyui-skill queue clear` | 清空排队中的任务 |
+| `comfyui-skill queue delete <prompt_id>...` | 从队列删除指定任务 |
+| `comfyui-skill free` | 释放 GPU 显存并卸载模型 |
+| `comfyui-skill free --models` | 仅卸载模型 |
+| `comfyui-skill free --memory` | 仅释放缓存 |
+
+### 模型发现
+
+| 命令 | 说明 |
+|------|------|
+| `comfyui-skill models list` | 列出所有模型文件夹 |
+| `comfyui-skill models list <folder>` | 列出指定文件夹中的模型（如 `checkpoints`、`loras`） |
 
 ### 工作流管理
 
 | 命令 | 说明 |
 |------|------|
-| `comfyui-skill workflow import <json_path>` | 从本地 JSON 导入工作流（自动检测格式、自动转换、自动生成 schema） |
-| `comfyui-skill workflow import --from-server` | 从 ComfyUI 服务器 userdata 导入工作流 |
-| `comfyui-skill workflow enable <workflow_id>` | 启用工作流 |
-| `comfyui-skill workflow disable <workflow_id>` | 禁用工作流 |
-| `comfyui-skill workflow delete <workflow_id>` | 删除工作流 |
+| `comfyui-skill workflow import <path>` | 导入工作流（自动检测格式、自动生成 schema） |
+| `comfyui-skill workflow import --from-server` | 从 ComfyUI 服务器导入 |
+| `comfyui-skill workflow enable <id>` | 启用工作流 |
+| `comfyui-skill workflow disable <id>` | 禁用工作流 |
+| `comfyui-skill workflow delete <id>` | 删除工作流 |
 
 ### 服务器管理
 
 | 命令 | 说明 |
 |------|------|
 | `comfyui-skill server list` | 列出所有已配置的服务器 |
-| `comfyui-skill server status [<server_id>]` | 检查 ComfyUI 服务器是否在线 |
-| `comfyui-skill server add --id <server_id> --url <url>` | 添加新服务器 |
-| `comfyui-skill server enable <server_id>` | 启用服务器 |
-| `comfyui-skill server disable <server_id>` | 禁用服务器 |
-| `comfyui-skill server remove <server_id>` | 移除服务器 |
+| `comfyui-skill server status` | 检查 ComfyUI 服务器是否在线 |
+| `comfyui-skill server add --id <id> --url <url>` | 添加新服务器 |
+| `comfyui-skill server enable/disable <id>` | 启用/禁用服务器 |
+| `comfyui-skill server remove <id>` | 移除服务器 |
 
 ### 依赖管理
 
 | 命令 | 说明 |
 |------|------|
-| `comfyui-skill deps check <workflow_id>` | 检查缺失的自定义节点和模型 |
-| `comfyui-skill deps install <workflow_id> --repos '[...]'` | 通过 Manager 安装缺失的自定义节点 |
-| `comfyui-skill deps install <workflow_id> --models` | 通过 Manager 安装缺失的模型 |
-| `comfyui-skill deps install <workflow_id> --all` | 自动检测并安装所有缺失的依赖 |
+| `comfyui-skill deps check <id>` | 检查缺失的自定义节点和模型 |
+| `comfyui-skill deps install <id> --all` | 自动检测并安装所有缺失依赖 |
+| `comfyui-skill deps install <id> --repos '[...]'` | 安装指定的自定义节点 |
+| `comfyui-skill deps install <id> --models` | 通过 Manager 安装缺失模型 |
 
-### 配置迁移
-
-| 命令 | 说明 |
-|------|------|
-| `comfyui-skill config export --output <path>` | 导出配置和工作流为 bundle |
-| `comfyui-skill config import <path>` | 导入 bundle（支持 --dry-run 预览） |
-
-### 执行历史
+### 配置与历史
 
 | 命令 | 说明 |
 |------|------|
-| `comfyui-skill history list <workflow_id>` | 查看工作流的执行历史 |
-| `comfyui-skill history show <workflow_id> <run_id>` | 查看单次运行的详细信息 |
+| `comfyui-skill config export --output <path>` | 导出配置和工作流 |
+| `comfyui-skill config import <path>` | 导入配置（支持 `--dry-run`） |
+| `comfyui-skill history list <id>` | 查看执行历史 |
+| `comfyui-skill history show <id> <run_id>` | 查看单次运行详情 |
 
 ### 全局选项
 
 | 选项 | 说明 |
 |------|------|
 | `--json, -j` | 强制 JSON 输出 |
-| `--server, -s <server_id>` | 指定服务器 ID |
-| `--dir, -d <path>` | 指定数据目录（默认：当前目录） |
+| `--output-format` | 输出格式：`text`、`json`、`stream-json` |
+| `--server, -s` | 指定服务器 ID |
+| `--dir, -d` | 指定数据目录（默认：当前目录） |
 | `--verbose, -v` | 详细输出 |
+| `--no-update-check` | 跳过自动更新检查 |
 
 ### 输出模式
 
-- **终端（TTY）** → Rich 表格 + 进度条（人类友好）
-- **管道 / `--json`** → 结构化 JSON（Agent 友好）
-- **错误** → 始终输出到 stderr
+| 模式 | 场景 | 格式 |
+|------|------|------|
+| Text | 终端 TTY | Rich 表格和进度条 |
+| JSON | 管道或 `--json` | 单次 JSON 结果 |
+| Stream JSON | `--output-format stream-json` | 实时 NDJSON 事件流 |
+| 错误 | 始终 | stderr |
 
 ## AI Agent 使用
 
-这个 CLI 专为 `SKILL.md` 调用场景设计：
+这个 CLI 专为 `SKILL.md` 调用场景设计。Agent 的典型流程：
 
 ```bash
-# Agent 的典型调用流程
-comfyui-skill server status --json                        # 1. 确认服务器在线
-comfyui-skill list --json                                 # 2. 发现可用工作流
-comfyui-skill info local/txt2img --json                   # 3. 查看参数要求
-comfyui-skill run local/txt2img --args '{...}' --json     # 4. 执行
+comfyui-skill server status --json                    # 1. 确认服务器
+comfyui-skill list --json                             # 2. 发现工作流
+comfyui-skill info local/txt2img --json               # 3. 查看参数
+comfyui-skill run local/txt2img --args '{...}' --json # 4. 执行
 ```
 
-### 导入新工作流
+### 工作流串联（多步管线）
 
 ```bash
-# 导入并检查依赖
-comfyui-skill workflow import ./workflow.json --check-deps --json
+# 执行第一个工作流
+comfyui-skill run local/txt2img --args '{"prompt": "a cat"}' --json
 
-# 安装缺失的依赖
+# 将输出串联到下一个工作流
+comfyui-skill upload --from-output <prompt_id> --json
+comfyui-skill run local/upscale --args '{"image": "<uploaded_name>"}' --json
+```
+
+### 导入并验证
+
+```bash
+comfyui-skill workflow import ./workflow.json --check-deps --json
 comfyui-skill deps install local/my-workflow --all --json
 ```
 
-## 退出码
+## 贡献
 
-| 代码 | 含义 |
-|------|------|
-| 0 | 成功 |
-| 1 | 一般错误 |
-| 2 | 参数无效 |
-| 3 | 服务器连接失败 |
-| 4 | 资源未找到 |
-| 5 | 执行失败 |
-| 6 | 超时 |
+欢迎贡献！请阅读主仓库的 [Contributing Guide](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/CONTRIBUTING.md) 了解设计原则和 PR 流程。
 
-## 兼容性
+## 相关资源
 
-基于 [Typer](https://typer.tiangolo.com/) 构建，与 [comfy-cli](https://github.com/Comfy-Org/comfy-cli) 使用相同框架。未来计划作为 `comfy skills` 子命令集成。
+- [ComfyUI Skills OpenClaw](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw) — 主仓库（Skills 定义）
+- [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — 本 CLI 调度的后端
+- [Typer](https://typer.tiangolo.com/) — 本项目使用的 CLI 框架


### PR DESCRIPTION
## Summary

- 重新设计 README 头部：居中布局 + PyPI/License/Python/Stars badges
- 补全新命令文档：cancel、queue、free、models、upload --from-output
- 新增工作流串联示例
- 新增 Contributing 章节
- 删除不准确的 exit codes（代码中只用了 0 和 1）
- 中英文 README 同步更新

## Test plan

- [ ] badges 链接正确显示
- [ ] 所有命令与 CLI 0.2.6 实际功能一致
- [ ] 中英文内容同步

🤖 Generated with [Claude Code](https://claude.com/claude-code)