### PR TITLE
[codex] docs: cover v0.6 cli capabilities in readmes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -41,6 +41,8 @@
 | **ゼロ設定** | カレントディレクトリの `config.json` と `data/` を読み込むため、すぐに使い始められます |
 | **ライフサイクル全体をカバー** | ワークフローの発見、インポート、実行、キャンセル、依存関係の管理まで 1 つのツールで対応できます |
 | **マルチサーバー対応** | 複数の ComfyUI インスタンスをまとめて管理し、ジョブを適切なハードウェアに振り分けられます |
+| **モデル探索** | 対象サーバー上のモデルフォルダと利用可能なモデル名を直接確認できます |
+| **複数ワークフロー管理** | 複数のワークフローをまとめてインポート、有効化、無効化、削除、移行できます |
 | **エラーガイダンス** | OOM、認証失敗、モデル不足など、よくある失敗に対して対処しやすいヒントを返します |
 
 ## インストール
@@ -107,7 +109,7 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 | `comfyui-skill info <id>` | ワークフロー詳細とパラメータ schema を表示 |
 | `comfyui-skill run <id> --args '{...}'` | ワークフローを実行（同期） |
 | `comfyui-skill submit <id> --args '{...}'` | ワークフローを送信（非同期） |
-| `comfyui-skill status <prompt_id>` | 実行状態を確認し、結果を取得 |
+| `comfyui-skill status <prompt_id>` | 実行状態を確認し、見つかった結果を表示 |
 | `comfyui-skill cancel <prompt_id>` | 実行中または待機中のジョブをキャンセル |
 | `comfyui-skill upload <file>` | ワークフローで使うためのファイルを ComfyUI にアップロード |
 | `comfyui-skill upload --from-output <prompt_id>` | 前回実行の出力を次のワークフロー入力として再利用 |
@@ -135,7 +137,7 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 | コマンド | 説明 |
 |----------|------|
 | `comfyui-skill workflow import <path>` | ワークフローをインポート（形式自動判別、schema 自動生成） |
-| `comfyui-skill workflow import --from-server` | ComfyUI サーバーからインポート |
+| `comfyui-skill workflow import --from-server` | ComfyUI サーバーの userdata から 1 つ以上のワークフローをインポート |
 | `comfyui-skill workflow enable <id>` | ワークフローを有効化 |
 | `comfyui-skill workflow disable <id>` | ワークフローを無効化 |
 | `comfyui-skill workflow delete <id>` | ワークフローを削除 |
@@ -187,6 +189,53 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 | JSON | パイプまたは `--json` | 単一の JSON 結果 |
 | Stream JSON | `--output-format stream-json` | リアルタイム NDJSON イベント |
 | Errors | 常に | stderr |
+
+## よくある管理タスク
+
+### サーバー上のモデルを確認する
+
+```bash
+comfyui-skill models list
+comfyui-skill models list checkpoints
+comfyui-skill models list loras
+```
+
+ワークフローや schema に書く前にモデル名を確認したいときに便利です。
+
+### 複数のワークフローを管理する
+
+```bash
+# ComfyUI サーバー userdata にあるワークフローをプレビュー
+comfyui-skill workflow import --from-server --preview
+
+# 名前に一致するワークフローをサーバーから取り込む
+comfyui-skill workflow import --from-server --name sdxl
+
+# 一時的に無効化 / 再度有効化
+comfyui-skill workflow disable local/old-flow
+comfyui-skill workflow enable local/old-flow
+
+# もう公開しないワークフローを削除
+comfyui-skill workflow delete local/old-flow
+```
+
+### ワークフローバンドルを別マシンへ移す
+
+```bash
+comfyui-skill config export --output ./bundle.json --portable-only
+comfyui-skill config import ./bundle.json --dry-run
+comfyui-skill config import ./bundle.json --apply-environment
+```
+
+複数のワークフローを一度に移したい場合は、個別に再インポートするよりこの方法の方が効率的です。
+
+### 実行前にモデルと依存関係を確認する
+
+```bash
+comfyui-skill deps check local/txt2img
+comfyui-skill deps install local/txt2img --models
+comfyui-skill deps install local/txt2img --all
+```
 
 ## AI エージェント向け
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 | **Zero config** | Reads `config.json` and `data/` from the current directory, no setup needed |
 | **Full lifecycle** | Discover, import, execute, cancel, manage workflows and dependencies in one tool |
 | **Multi-server** | Manage multiple ComfyUI instances, route jobs to different hardware |
+| **Model discovery** | Inspect model folders and available model names directly from the target server |
+| **Workflow fleet management** | Import, enable, disable, delete, and migrate multiple workflows across machines |
 | **Error guidance** | Common failures (OOM, unauthorized, missing models) return actionable hints |
 
 <a id="install"></a>
@@ -110,7 +112,7 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 | `comfyui-skill info <id>` | Show workflow details and parameter schema |
 | `comfyui-skill run <id> --args '{...}'` | Execute a workflow (blocking) |
 | `comfyui-skill submit <id> --args '{...}'` | Submit a workflow (non-blocking) |
-| `comfyui-skill status <prompt_id>` | Check execution status and download results |
+| `comfyui-skill status <prompt_id>` | Check execution status and show discovered results |
 | `comfyui-skill cancel <prompt_id>` | Cancel a running or queued job |
 | `comfyui-skill upload <file>` | Upload a file to ComfyUI for use in workflows |
 | `comfyui-skill upload --from-output <prompt_id>` | Chain a previous run's output as input for the next workflow |
@@ -138,7 +140,7 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 | Command | Description |
 |---------|-------------|
 | `comfyui-skill workflow import <path>` | Import workflow (auto-detect format, auto-generate schema) |
-| `comfyui-skill workflow import --from-server` | Import from ComfyUI server userdata |
+| `comfyui-skill workflow import --from-server` | Import one or more workflows from ComfyUI server userdata |
 | `comfyui-skill workflow enable <id>` | Enable a workflow |
 | `comfyui-skill workflow disable <id>` | Disable a workflow |
 | `comfyui-skill workflow delete <id>` | Delete a workflow |
@@ -190,6 +192,53 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 | JSON | Pipe or `--json` | Single JSON result |
 | Stream JSON | `--output-format stream-json` | NDJSON events in real time |
 | Errors | Always | stderr |
+
+## Common Management Tasks
+
+### Inspect models on a server
+
+```bash
+comfyui-skill models list
+comfyui-skill models list checkpoints
+comfyui-skill models list loras
+```
+
+Use this when you need to confirm model names before wiring them into a workflow or schema.
+
+### Manage multiple workflows
+
+```bash
+# Preview workflows available in ComfyUI server userdata
+comfyui-skill workflow import --from-server --preview
+
+# Import matching workflows from the server
+comfyui-skill workflow import --from-server --name sdxl
+
+# Temporarily disable or re-enable a workflow
+comfyui-skill workflow disable local/old-flow
+comfyui-skill workflow enable local/old-flow
+
+# Remove a workflow you no longer want to expose
+comfyui-skill workflow delete local/old-flow
+```
+
+### Move workflow bundles between machines
+
+```bash
+comfyui-skill config export --output ./bundle.json --portable-only
+comfyui-skill config import ./bundle.json --dry-run
+comfyui-skill config import ./bundle.json --apply-environment
+```
+
+Use this when you want to migrate many workflows at once instead of re-importing them manually.
+
+### Check models and dependencies before running
+
+```bash
+comfyui-skill deps check local/txt2img
+comfyui-skill deps install local/txt2img --models
+comfyui-skill deps install local/txt2img --all
+```
 
 <a id="for-ai-agents"></a>
 ## For AI Agents

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -41,6 +41,8 @@
 | **零設定** | 從目前目錄讀取 `config.json` 和 `data/`，幾乎開箱即用 |
 | **完整生命週期** | 發現、匯入、執行、取消，以及管理工作流程與依賴，全都整合在同一個工具裡 |
 | **多伺服器** | 同時管理多台 ComfyUI 實例，依需求把任務分派到不同硬體 |
+| **模型探索** | 直接從目標伺服器查看模型資料夾與可用模型名稱 |
+| **多工作流程管理** | 支援批次匯入、啟用、停用、刪除與遷移多套工作流程 |
 | **錯誤引導** | 常見失敗（顯存不足、未授權、模型缺失）都會回傳可操作的提示 |
 
 ## 安裝
@@ -107,7 +109,7 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 | `comfyui-skill info <id>` | 查看工作流程詳情與參數 schema |
 | `comfyui-skill run <id> --args '{...}'` | 執行工作流程（阻塞） |
 | `comfyui-skill submit <id> --args '{...}'` | 提交工作流程（非阻塞） |
-| `comfyui-skill status <prompt_id>` | 查詢執行狀態並下載結果 |
+| `comfyui-skill status <prompt_id>` | 查詢執行狀態並顯示已找到的結果 |
 | `comfyui-skill cancel <prompt_id>` | 取消執行中或排隊中的任務 |
 | `comfyui-skill upload <file>` | 上傳檔案到 ComfyUI，供工作流程使用 |
 | `comfyui-skill upload --from-output <prompt_id>` | 將前一次執行的輸出串接成下一個工作流程的輸入 |
@@ -135,7 +137,7 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 | 命令 | 說明 |
 |------|------|
 | `comfyui-skill workflow import <path>` | 匯入工作流程（自動偵測格式、自動產生 schema） |
-| `comfyui-skill workflow import --from-server` | 從 ComfyUI 伺服器匯入 |
+| `comfyui-skill workflow import --from-server` | 從 ComfyUI 伺服器 userdata 匯入一個或多個工作流程 |
 | `comfyui-skill workflow enable <id>` | 啟用工作流程 |
 | `comfyui-skill workflow disable <id>` | 停用工作流程 |
 | `comfyui-skill workflow delete <id>` | 刪除工作流程 |
@@ -187,6 +189,53 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 | JSON | 管線或 `--json` | 單次 JSON 結果 |
 | Stream JSON | `--output-format stream-json` | 即時 NDJSON 事件流 |
 | 錯誤 | 一律 | stderr |
+
+## 常見管理情境
+
+### 查看伺服器上的模型
+
+```bash
+comfyui-skill models list
+comfyui-skill models list checkpoints
+comfyui-skill models list loras
+```
+
+當你需要先確認模型名稱，再寫進工作流程或 schema 時，這組命令最直接。
+
+### 管理多套工作流程
+
+```bash
+# 預覽 ComfyUI 伺服器 userdata 中可匯入的工作流程
+comfyui-skill workflow import --from-server --preview
+
+# 從伺服器匯入符合名稱的工作流程
+comfyui-skill workflow import --from-server --name sdxl
+
+# 暫時停用或重新啟用工作流程
+comfyui-skill workflow disable local/old-flow
+comfyui-skill workflow enable local/old-flow
+
+# 刪除不再需要對外暴露的工作流程
+comfyui-skill workflow delete local/old-flow
+```
+
+### 在不同機器之間遷移工作流程包
+
+```bash
+comfyui-skill config export --output ./bundle.json --portable-only
+comfyui-skill config import ./bundle.json --dry-run
+comfyui-skill config import ./bundle.json --apply-environment
+```
+
+如果你想一次遷移多套工作流程，而不是逐一手動重新匯入，這組命令會更有效率。
+
+### 執行前檢查模型與依賴
+
+```bash
+comfyui-skill deps check local/txt2img
+comfyui-skill deps install local/txt2img --models
+comfyui-skill deps install local/txt2img --all
+```
 
 ## AI Agent 使用
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -41,6 +41,8 @@
 | **零配置** | 从当前目录读取 `config.json` 和 `data/`，开箱即用 |
 | **全生命周期** | 发现、导入、执行、取消、管理工作流和依赖，一个工具搞定 |
 | **多服务器** | 同时管理多台 ComfyUI 实例，按需分发任务到不同算力 |
+| **模型发现** | 直接从目标服务器查看模型目录和可用模型名称 |
+| **多工作流管理** | 支持批量导入、启用、禁用、删除和迁移多套工作流 |
 | **错误引导** | 常见失败（显存不足、未授权、模型缺失）自动返回可操作的提示 |
 
 ## 安装
@@ -107,7 +109,7 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | `comfyui-skill info <id>` | 查看工作流详情和参数 schema |
 | `comfyui-skill run <id> --args '{...}'` | 执行工作流（阻塞） |
 | `comfyui-skill submit <id> --args '{...}'` | 提交工作流（非阻塞） |
-| `comfyui-skill status <prompt_id>` | 查询执行状态 |
+| `comfyui-skill status <prompt_id>` | 查询执行状态并显示已发现的结果 |
 | `comfyui-skill cancel <prompt_id>` | 取消运行中或排队中的任务 |
 | `comfyui-skill upload <file>` | 上传文件到 ComfyUI 供工作流使用 |
 | `comfyui-skill upload --from-output <prompt_id>` | 将上次运行的输出作为下一个工作流的输入 |
@@ -135,7 +137,7 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | 命令 | 说明 |
 |------|------|
 | `comfyui-skill workflow import <path>` | 导入工作流（自动检测格式、自动生成 schema） |
-| `comfyui-skill workflow import --from-server` | 从 ComfyUI 服务器导入 |
+| `comfyui-skill workflow import --from-server` | 从 ComfyUI 服务器 userdata 导入一个或多个工作流 |
 | `comfyui-skill workflow enable <id>` | 启用工作流 |
 | `comfyui-skill workflow disable <id>` | 禁用工作流 |
 | `comfyui-skill workflow delete <id>` | 删除工作流 |
@@ -187,6 +189,53 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | JSON | 管道或 `--json` | 单次 JSON 结果 |
 | Stream JSON | `--output-format stream-json` | 实时 NDJSON 事件流 |
 | 错误 | 始终 | stderr |
+
+## 常见管理场景
+
+### 查看服务器上的模型
+
+```bash
+comfyui-skill models list
+comfyui-skill models list checkpoints
+comfyui-skill models list loras
+```
+
+当你需要确认模型名称，再写进工作流或 schema 时，这组命令最直接。
+
+### 管理多套工作流
+
+```bash
+# 预览 ComfyUI 服务器 userdata 中可导入的工作流
+comfyui-skill workflow import --from-server --preview
+
+# 从服务器导入匹配名称的工作流
+comfyui-skill workflow import --from-server --name sdxl
+
+# 临时禁用或重新启用工作流
+comfyui-skill workflow disable local/old-flow
+comfyui-skill workflow enable local/old-flow
+
+# 删除不再需要暴露的工作流
+comfyui-skill workflow delete local/old-flow
+```
+
+### 在不同机器之间迁移工作流包
+
+```bash
+comfyui-skill config export --output ./bundle.json --portable-only
+comfyui-skill config import ./bundle.json --dry-run
+comfyui-skill config import ./bundle.json --apply-environment
+```
+
+如果你要一次迁移多套工作流，而不是逐个手动重新导入，这组命令会更高效。
+
+### 运行前检查模型和依赖
+
+```bash
+comfyui-skill deps check local/txt2img
+comfyui-skill deps install local/txt2img --models
+comfyui-skill deps install local/txt2img --all
+```
 
 ## AI Agent 使用
 


### PR DESCRIPTION
## Summary

- surface v0.6 CLI capabilities more clearly across all README variants
- expand coverage for model discovery, multi-workflow management, workflow import, config migration, and dependency checks
- keep behavior unchanged; documentation only

## Validation

- `git diff --check`
