### PR TITLE
fix: upload image files before queuing workflow

### DIFF
--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -42,7 +42,7 @@ def run_cmd(
     workflow = _inject_params(workflow_data, parameters, input_args)
 
     # Upload image files before submitting
-    _upload_media(client, workflow, parameters, input_args)
+    _upload_media(ctx, client, workflow, parameters, input_args)
 
     # Submit
     try:
@@ -135,7 +135,7 @@ def submit_cmd(
     workflow = _inject_params(workflow_data, parameters, input_args)
 
     # Upload image files before submitting
-    _upload_media(client, workflow, parameters, input_args)
+    _upload_media(ctx, client, workflow, parameters, input_args)
 
     try:
         result = client.queue_prompt(workflow)
@@ -268,6 +268,7 @@ def _inject_params(
 
 
 def _upload_media(
+    ctx: typer.Context,
     client: "ComfyUIClient",
     workflow: dict[str, Any],
     parameters: dict[str, Any],
@@ -282,8 +283,8 @@ def _upload_media(
             continue
         if not isinstance(value, str) or not value:
             continue
-        # Already a plain filename (no path separator) — skip
-        if "/" not in value and "\\" not in value:
+        # Not a local file — treat as existing filename in input folder
+        if not os.path.isfile(value):
             continue
         # Upload the file
         try:
@@ -296,7 +297,8 @@ def _upload_media(
                     workflow[node_id]["inputs"][field] = uploaded_name
                     logger.info("Uploaded %s → %s (node %s.%s)", value, uploaded_name, node_id, field)
         except Exception as exc:
-            logger.warning("Failed to upload %s: %s", value, exc)
+            output_error(ctx, "UPLOAD_FAILED", f"Failed to upload {value}: {exc}")
+            raise typer.Exit(code=1)
 
 
 _MEDIA_KEYS: dict[str, str] = {

--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -171,6 +171,7 @@ def status_cmd(
         outputs = history.get("outputs", {})
         if status_info.get("completed", False) or outputs:
             collected = _collect_outputs(outputs)
+            collected = _download_outputs(client, collected, base_dir, server_config)
             output_result(ctx, {"status": "success", "prompt_id": prompt_id, "outputs": collected})
             return
         if status_info.get("status_str") == "error":

--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -41,6 +41,9 @@ def run_cmd(
     # Inject parameters into workflow
     workflow = _inject_params(workflow_data, parameters, input_args)
 
+    # Upload image files before submitting
+    _upload_media(client, workflow, parameters, input_args)
+
     # Submit
     try:
         result = client.queue_prompt(workflow)
@@ -130,6 +133,9 @@ def submit_cmd(
     input_args = _parse_args(ctx, args)
     parameters = _get_parameters(schema_data)
     workflow = _inject_params(workflow_data, parameters, input_args)
+
+    # Upload image files before submitting
+    _upload_media(client, workflow, parameters, input_args)
 
     try:
         result = client.queue_prompt(workflow)
@@ -259,6 +265,38 @@ def _inject_params(
         if node_id in workflow and isinstance(workflow[node_id], dict) and "inputs" in workflow[node_id]:
             workflow[node_id]["inputs"][field] = value
     return workflow
+
+
+def _upload_media(
+    client: "ComfyUIClient",
+    workflow: dict[str, Any],
+    parameters: dict[str, Any],
+    args: dict[str, Any],
+) -> None:
+    """Upload image/audio/video files and replace paths with uploaded filenames."""
+    for key, value in args.items():
+        if key not in parameters:
+            continue
+        param = parameters[key]
+        if param.get("type") != "image":
+            continue
+        if not isinstance(value, str) or not value:
+            continue
+        # Already a plain filename (no path separator) — skip
+        if "/" not in value and "\\" not in value:
+            continue
+        # Upload the file
+        try:
+            result = client.upload_image(value)
+            uploaded_name = result.get("name", "")
+            if uploaded_name:
+                node_id = str(param.get("node_id", ""))
+                field = param.get("field", "")
+                if node_id in workflow and isinstance(workflow[node_id], dict) and "inputs" in workflow[node_id]:
+                    workflow[node_id]["inputs"][field] = uploaded_name
+                    logger.info("Uploaded %s → %s (node %s.%s)", value, uploaded_name, node_id, field)
+        except Exception as exc:
+            logger.warning("Failed to upload %s: %s", value, exc)
 
 
 _MEDIA_KEYS: dict[str, str] = {


### PR DESCRIPTION
## Bug

When a skill parameter of type `image` receives a local file path, the CLI injects the raw path into the workflow JSON and submits it directly to ComfyUI. Since ComfyUI's `LoadImage` node expects a filename already present in its input directory, this causes a 400 error.

## Fix

Added a `_upload_media()` step between `_inject_params()` and `queue_prompt()` that:
1. Detects image-type parameters with local file paths
2. Calls `client.upload_image()` to upload them to ComfyUI
3. Replaces the value with the uploaded filename before submission

## Tested

- ✅ `comfyui-skill run` with local image path → uploads and runs successfully
- ✅ Plain filenames (already in ComfyUI input dir) are skipped
- ✅ `comfyui-skill submit` also updated