### PR TITLE
feat: add nodes discovery command and WebSocket streaming for run

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,10 +276,8 @@ Contributions are welcome! Please read the [Contributing Guide](https://github.c
 
 ## Resources
 
-<<<<<<< HEAD
 - [ComfyUI Skills OpenClaw](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw) — Main skills repository
 - [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — The backend this CLI orchestrates
 - [Typer](https://typer.tiangolo.com/) — CLI framework used by this project
-=======
+
 Built with [Typer](https://typer.tiangolo.com/), the same framework as [comfy-cli](https://github.com/Comfy-Org/comfy-cli). Designed to be integrated as a `comfy skills` subcommand in the future.
->>>>>>> 246e194 (docs: add zh-TW and ja readmes)

--- a/comfyui_skills_cli/client.py
+++ b/comfyui_skills_cli/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 import uuid
-from typing import Any
+from typing import Any, Generator
 
 import requests
 
@@ -52,16 +52,19 @@ class ComfyUIClient:
 
     # -- Prompt execution --
 
-    def queue_prompt(self, workflow: dict[str, Any]) -> dict[str, Any]:
+    def queue_prompt(self, workflow: dict[str, Any], client_id: str | None = None) -> dict[str, Any]:
+        cid = client_id or str(uuid.uuid4())
         payload: dict[str, Any] = {
             "prompt": workflow,
-            "client_id": str(uuid.uuid4()),
+            "client_id": cid,
         }
         if self.comfy_api_key:
             payload["extra_data"] = {"api_key_comfy_org": self.comfy_api_key}
         resp = self._post("/prompt", json_data=payload)
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        data["client_id"] = cid
+        return data
 
     def get_history(self, prompt_id: str) -> dict[str, Any] | None:
         resp = self._get(f"/history/{prompt_id}")
@@ -74,6 +77,34 @@ class ComfyUIClient:
         resp = self._get("/queue")
         resp.raise_for_status()
         return resp.json()
+
+    def ws_events(self, client_id: str, prompt_id: str) -> Generator[dict[str, Any], None, None]:
+        import websocket
+        ws_url = self.server_url.replace("http://", "ws://").replace("https://", "wss://")
+        ws = websocket.create_connection(
+            f"{ws_url}/ws?clientId={client_id}",
+            timeout=self.timeout,
+        )
+        ws.settimeout(None)
+        try:
+            while True:
+                opcode, raw = ws.recv_data()
+                if opcode == websocket.ABNF.OPCODE_BINARY:
+                    continue
+                if opcode != websocket.ABNF.OPCODE_TEXT:
+                    continue
+                msg = json.loads(raw)
+                event_type = msg.get("type", "")
+                data = msg.get("data", {})
+                if data.get("prompt_id") and data["prompt_id"] != prompt_id:
+                    continue
+                yield {"type": event_type, "data": data}
+                if event_type in ("execution_error", "execution_interrupted"):
+                    break
+                if event_type == "executing" and data.get("node") is None:
+                    break
+        finally:
+            ws.close()
 
     def download_output(self, filename: str, subfolder: str = "", output_type: str = "output") -> bytes:
         resp = self._get("/view", params={
@@ -90,6 +121,14 @@ class ComfyUIClient:
         resp = self._get("/object_info")
         resp.raise_for_status()
         return resp.json()
+
+    def get_object_info_node(self, node_class: str) -> dict[str, Any] | None:
+        resp = self._get(f"/object_info/{node_class}")
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get(node_class)
 
     def get_model_folders(self) -> list[str]:
         resp = self._get("/models")

--- a/comfyui_skills_cli/commands/nodes.py
+++ b/comfyui_skills_cli/commands/nodes.py
@@ -1,0 +1,180 @@
+"""comfyui-skill nodes — discover available ComfyUI nodes."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..client import ComfyUIClient
+from ..config import get_base_dir, get_default_server_id, get_server, load_config
+from ..output import get_output_format, OutputFormat, output_error, output_result
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _build_client(ctx: typer.Context) -> ComfyUIClient:
+    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
+    config = load_config(base_dir)
+    server_id = ctx.obj.get("server") or get_default_server_id(config)
+    server_config = get_server(config, server_id)
+
+    if not server_config:
+        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
+
+    return ComfyUIClient(
+        server_url=server_config.get("url", "http://127.0.0.1:8188"),
+        auth=server_config.get("auth", ""),
+    )
+
+
+def _flatten_nodes(all_info: dict, category_filter: str = "") -> list[dict]:
+    rows = []
+    for class_type, info in all_info.items():
+        cat = info.get("category", "")
+        if category_filter and category_filter.lower() != cat.lower():
+            continue
+        rows.append({
+            "class_type": class_type,
+            "display_name": info.get("display_name", class_type),
+            "category": cat,
+            "description": info.get("description", ""),
+        })
+    rows.sort(key=lambda r: (r["category"].lower(), r["display_name"].lower()))
+    return rows
+
+
+def _print_node_table(rows: list[dict]) -> None:
+    console = Console()
+    table = Table(show_lines=True)
+    table.add_column("category")
+    table.add_column("class_type")
+    table.add_column("display_name")
+    for r in rows:
+        table.add_row(r["category"], r["class_type"], r["display_name"])
+    console.print(table)
+
+
+@app.command("list")
+def nodes_list(
+    ctx: typer.Context,
+    category: Optional[str] = typer.Option(None, "--category", "-c", help="Filter by category"),
+):
+    """List all available node classes, grouped by category."""
+    client = _build_client(ctx)
+    try:
+        all_info = client.get_object_info()
+    except Exception as exc:
+        output_error(ctx, "NODES_FAILED", f"Failed to fetch nodes: {exc}")
+
+    rows = _flatten_nodes(all_info, category or "")
+
+    fmt = get_output_format(ctx)
+    if fmt in (OutputFormat.JSON, OutputFormat.STREAM_JSON):
+        output_result(ctx, rows)
+    else:
+        _print_node_table(rows)
+
+
+@app.command("info")
+def nodes_info(
+    ctx: typer.Context,
+    node_class: str = typer.Argument(help="Node class name (e.g. KSampler)"),
+):
+    """Show full details of a single node class."""
+    client = _build_client(ctx)
+    try:
+        info = client.get_object_info_node(node_class)
+    except Exception as exc:
+        output_error(ctx, "NODES_FAILED", f"Failed to fetch node info: {exc}")
+
+    if not info:
+        output_error(ctx, "NODE_NOT_FOUND", f'Node class "{node_class}" not found.')
+
+    fmt = get_output_format(ctx)
+    if fmt in (OutputFormat.JSON, OutputFormat.STREAM_JSON):
+        output_result(ctx, info)
+        return
+
+    console = Console()
+    console.print(f"[bold]display_name:[/bold] {info.get('display_name', node_class)}")
+    console.print(f"[bold]category:[/bold] {info.get('category', '')}")
+    console.print(f"[bold]description:[/bold] {info.get('description', '') or '-'}")
+
+    inp = info.get("input", {})
+    input_order = info.get("input_order", {})
+
+    required = inp.get("required", {})
+    if required:
+        console.print("\n[bold]input_required:[/bold]")
+        for name in input_order.get("required", list(required.keys())):
+            spec = required.get(name, [])
+            if not spec:
+                continue
+            type_info = spec[0]
+            if isinstance(type_info, list):
+                options = ", ".join(str(o) for o in type_info[:8])
+                if len(type_info) > 8:
+                    options += ", ..."
+                console.print(f"  [cyan]{name}[/cyan] (COMBO): [{options}]")
+            else:
+                console.print(f"  [cyan]{name}[/cyan] ({type_info})")
+
+    optional = inp.get("optional", {})
+    if optional:
+        console.print("\n[bold]input_optional:[/bold]")
+        for name in input_order.get("optional", list(optional.keys())):
+            spec = optional.get(name, [])
+            if not spec:
+                continue
+            type_info = spec[0]
+            if isinstance(type_info, list):
+                options = ", ".join(str(o) for o in type_info[:8])
+                if len(type_info) > 8:
+                    options += ", ..."
+                console.print(f"  [cyan]{name}[/cyan] (COMBO): [{options}]")
+            else:
+                console.print(f"  [cyan]{name}[/cyan] ({type_info})")
+
+    output_names = info.get("output_name", [])
+    output_types = info.get("output", [])
+    if output_names:
+        console.print("\n[bold]outputs:[/bold]")
+        for i, name in enumerate(output_names):
+            otype = output_types[i] if i < len(output_types) else ""
+            console.print(f"  [cyan]{name}[/cyan] ({otype})")
+
+
+@app.command("search")
+def nodes_search(
+    ctx: typer.Context,
+    query: str = typer.Argument(help="Search query (substring match)"),
+):
+    """Fuzzy search across node names, display names, and categories."""
+    client = _build_client(ctx)
+    try:
+        all_info = client.get_object_info()
+    except Exception as exc:
+        output_error(ctx, "NODES_FAILED", f"Failed to fetch nodes: {exc}")
+
+    q = query.lower()
+    rows = []
+    for class_type, info in all_info.items():
+        display_name = info.get("display_name", class_type)
+        cat = info.get("category", "")
+        if q in class_type.lower() or q in display_name.lower() or q in cat.lower():
+            rows.append({
+                "class_type": class_type,
+                "display_name": display_name,
+                "category": cat,
+                "description": info.get("description", ""),
+            })
+    rows.sort(key=lambda r: (r["category"].lower(), r["display_name"].lower()))
+
+    fmt = get_output_format(ctx)
+    if fmt in (OutputFormat.JSON, OutputFormat.STREAM_JSON):
+        output_result(ctx, rows)
+    else:
+        _print_node_table(rows)

--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -26,6 +26,14 @@ _POLL_MAX = 10.0
 _POLL_FACTOR = 1.5
 
 
+def _ws_available() -> bool:
+    try:
+        import websocket  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
 def run_cmd(
     ctx: typer.Context,
     skill_id: str = typer.Argument(help="Skill ID: server_id/workflow_id or workflow_id"),
@@ -37,30 +45,138 @@ def run_cmd(
 
     input_args = _parse_args(ctx, args)
     parameters = _get_parameters(schema_data)
-
-    # Inject parameters into workflow
     workflow = _inject_params(workflow_data, parameters, input_args)
 
-    # Submit
+    client_id = str(uuid.uuid4())
+
     try:
-        result = client.queue_prompt(workflow)
+        result = client.queue_prompt(workflow, client_id=client_id)
     except Exception as exc:
         output_error(ctx, "SUBMIT_FAILED", f"Failed to submit workflow: {exc}")
         return
 
     prompt_id = result.get("prompt_id", "")
     fmt = get_output_format(ctx)
-
-    # stream-json: emit events as they happen
     output_event(ctx, "queued", prompt_id=prompt_id)
 
-    # Rich progress for text mode
     if fmt == OutputFormat.TEXT:
         from rich.console import Console
         console = Console(stderr=True)
         console.print(f"[dim]Queued: {prompt_id}[/dim]")
 
-    # Poll until complete
+    if _ws_available():
+        try:
+            _run_with_ws(ctx, client, workflow, prompt_id, client_id, base_dir, server_config, fmt)
+            return
+        except Exception:
+            logger.debug("WebSocket failed, falling back to polling", exc_info=True)
+
+    _run_with_poll(ctx, client, prompt_id, base_dir, server_config, fmt)
+
+
+def _run_with_ws(
+    ctx: typer.Context,
+    client: ComfyUIClient,
+    workflow: dict[str, Any],
+    prompt_id: str,
+    client_id: str,
+    base_dir: Any,
+    server_config: dict[str, Any],
+    fmt: OutputFormat,
+) -> None:
+    if fmt == OutputFormat.TEXT:
+        from rich.console import Console
+        console = Console(stderr=True)
+
+    node_classes: dict[str, str] = {}
+    for node_id, node_data in workflow.items():
+        if isinstance(node_data, dict) and "class_type" in node_data:
+            node_classes[str(node_id)] = node_data["class_type"]
+
+    for event in client.ws_events(client_id, prompt_id):
+        etype = event["type"]
+        data = event["data"]
+
+        if etype == "execution_start":
+            output_event(ctx, "started", prompt_id=prompt_id)
+            if fmt == OutputFormat.TEXT:
+                console.print("[yellow]Running...[/yellow]")
+
+        elif etype == "execution_cached":
+            nodes = data.get("nodes", [])
+            output_event(ctx, "cached", prompt_id=prompt_id, nodes=nodes)
+
+        elif etype == "executing":
+            node = data.get("node")
+            if node is None:
+                break
+            display = node_classes.get(node, node)
+            output_event(ctx, "node_executing", prompt_id=prompt_id, node=node, node_display=display)
+            if fmt == OutputFormat.TEXT:
+                console.print(f"  [cyan]{display}[/cyan] ({node})")
+
+        elif etype == "executed":
+            node = data.get("node", "")
+            display = node_classes.get(node, node)
+            output_event(ctx, "node_completed", prompt_id=prompt_id, node=node, node_display=display, outputs=data.get("output", {}))
+
+        elif etype == "progress":
+            node = data.get("node", "")
+            value = data.get("value", 0)
+            max_val = data.get("max", 0)
+            display = node_classes.get(node, node)
+            output_event(ctx, "progress", prompt_id=prompt_id, node=node, node_display=display, value=value, max=max_val)
+            if fmt == OutputFormat.TEXT and max_val > 0:
+                pct = int(value / max_val * 100)
+                console.print(f"    [dim]{display} {value}/{max_val} ({pct}%)[/dim]", highlight=False)
+
+        elif etype == "execution_error":
+            error_msg = data.get("exception_message", "Execution error")
+            hint = match_error_hint(error_msg)
+            output_event(ctx, "error", prompt_id=prompt_id, message=error_msg)
+            output_error(ctx, "EXECUTION_FAILED", error_msg, hint=hint)
+            return
+
+        elif etype == "execution_interrupted":
+            output_error(ctx, "EXECUTION_INTERRUPTED", "Execution was interrupted")
+            return
+
+    history = client.get_history(prompt_id)
+    if history:
+        status_info = history.get("status", {})
+        if status_info.get("status_str") == "error":
+            error_msg = _format_errors(history)
+            hint = match_error_hint(error_msg)
+            output_event(ctx, "error", prompt_id=prompt_id, message=error_msg)
+            output_error(ctx, "EXECUTION_FAILED", error_msg, hint=hint)
+            return
+        outputs = history.get("outputs", {})
+        collected = _collect_outputs(outputs)
+        collected = _download_outputs(client, collected, base_dir, server_config)
+    else:
+        collected = []
+
+    output_event(ctx, "completed", prompt_id=prompt_id, outputs=collected)
+    if fmt != OutputFormat.STREAM_JSON:
+        output_result(ctx, {
+            "status": "success",
+            "prompt_id": prompt_id,
+            "outputs": collected,
+        })
+
+
+def _run_with_poll(
+    ctx: typer.Context,
+    client: ComfyUIClient,
+    prompt_id: str,
+    base_dir: Any,
+    server_config: dict[str, Any],
+    fmt: OutputFormat,
+) -> None:
+    if fmt == OutputFormat.TEXT:
+        from rich.console import Console
+        console = Console(stderr=True)
+
     poll_interval = _POLL_INITIAL
     prev_status = ""
     while True:
@@ -73,8 +189,6 @@ def run_cmd(
                 collected = _collect_outputs(outputs)
                 collected = _download_outputs(client, collected, base_dir, server_config)
                 output_event(ctx, "completed", prompt_id=prompt_id, outputs=collected)
-
-                # Final result — json and stream-json both get this
                 if fmt == OutputFormat.STREAM_JSON:
                     return
                 output_result(ctx, {
@@ -91,7 +205,6 @@ def run_cmd(
                 output_error(ctx, "EXECUTION_FAILED", error_msg, hint=hint)
                 return
 
-        # Check queue position
         queue = client.get_queue()
         current_status = ""
         for item in queue.get("queue_running", []):

--- a/comfyui_skills_cli/main.py
+++ b/comfyui_skills_cli/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typer
 
 from . import __version__
-from .commands import cancel, config, deps, free, history, models, queue, run, server, skill, upload, workflow
+from .commands import cancel, config, deps, free, history, models, nodes, queue, run, server, skill, upload, workflow
 from .update_check import is_machine_output, maybe_notify_update
 
 app = typer.Typer(
@@ -49,7 +49,7 @@ def main(
 
 
 # Subcommand groups — each needs a callback to inherit parent context
-for sub_app in [config.app, deps.app, history.app, models.app, queue.app, server.app, workflow.app]:
+for sub_app in [config.app, deps.app, history.app, models.app, nodes.app, queue.app, server.app, workflow.app]:
     @sub_app.callback()
     def _pass_context(ctx: typer.Context):
         if ctx.parent and ctx.parent.obj:
@@ -58,6 +58,7 @@ for sub_app in [config.app, deps.app, history.app, models.app, queue.app, server
 
 app.add_typer(config.app, name="config", help="Import/export configuration")
 app.add_typer(models.app, name="models", help="Discover available models")
+app.add_typer(nodes.app, name="nodes", help="Discover available ComfyUI nodes")
 app.add_typer(deps.app, name="deps", help="Manage dependencies")
 app.add_typer(history.app, name="history", help="Execution history")
 app.add_typer(queue.app, name="queue", help="View and manage execution queue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,11 @@ dependencies = [
     "typer>=0.9",
     "rich>=13.0",
     "requests>=2.28",
+    "websocket-client>=1.0",
 ]
+
+[project.optional-dependencies]
+streaming = ["websocket-client>=1.0"]
 
 [project.urls]
 Homepage = "https://github.com/HuangYuChuh/ComfyUI_Skill_CLI"

--- a/tests/test_nodes_and_ws.py
+++ b/tests/test_nodes_and_ws.py
@@ -1,0 +1,203 @@
+"""Tests for nodes command helpers and WebSocket client methods."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from comfyui_skills_cli.client import ComfyUIClient
+
+
+SAMPLE_OBJECT_INFO = {
+    "KSampler": {
+        "input": {
+            "required": {
+                "model": ["MODEL"],
+                "seed": ["INT", {"default": 0, "min": 0, "max": 2**64 - 1}],
+                "sampler_name": [["euler", "euler_ancestral", "heun"]],
+            },
+            "optional": {},
+        },
+        "input_order": {"required": ["model", "seed", "sampler_name"], "optional": []},
+        "output": ["LATENT"],
+        "output_is_list": [False],
+        "output_name": ["LATENT"],
+        "name": "KSampler",
+        "display_name": "KSampler",
+        "description": "Samples latents",
+        "category": "sampling",
+    },
+    "CLIPTextEncode": {
+        "input": {"required": {"text": ["STRING"], "clip": ["CLIP"]}, "optional": {}},
+        "input_order": {"required": ["text", "clip"], "optional": []},
+        "output": ["CONDITIONING"],
+        "output_is_list": [False],
+        "output_name": ["CONDITIONING"],
+        "name": "CLIPTextEncode",
+        "display_name": "CLIP Text Encode",
+        "description": "",
+        "category": "conditioning",
+    },
+}
+
+
+class ObjectInfoNodeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_object_info_node_found(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"KSampler": SAMPLE_OBJECT_INFO["KSampler"]},
+        )
+        result = self.client.get_object_info_node("KSampler")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["display_name"], "KSampler")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_object_info_node_not_found(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = MagicMock(status_code=404)
+        result = self.client.get_object_info_node("NonExistentNode")
+        self.assertIsNone(result)
+
+
+class QueuePromptClientIdTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.post")
+    def test_queue_prompt_with_client_id(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"prompt_id": "p-123"},
+        )
+        mock_post.return_value.raise_for_status = MagicMock()
+        result = self.client.queue_prompt({"1": {}}, client_id="my-client-id")
+        self.assertEqual(result["client_id"], "my-client-id")
+        self.assertEqual(result["prompt_id"], "p-123")
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(payload["client_id"], "my-client-id")
+
+    @patch("comfyui_skills_cli.client.requests.post")
+    def test_queue_prompt_generates_client_id(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"prompt_id": "p-456"},
+        )
+        mock_post.return_value.raise_for_status = MagicMock()
+        result = self.client.queue_prompt({"1": {}})
+        self.assertIn("client_id", result)
+        self.assertTrue(len(result["client_id"]) > 0)
+
+
+class WsEventsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("websocket.create_connection")
+    def test_ws_events_yields_matching_events(self, mock_ws_create: MagicMock) -> None:
+        import websocket
+
+        mock_ws = MagicMock()
+        mock_ws_create.return_value = mock_ws
+
+        events = [
+            (websocket.ABNF.OPCODE_TEXT, json.dumps({
+                "type": "execution_start",
+                "data": {"prompt_id": "p-1"},
+            }).encode()),
+            (websocket.ABNF.OPCODE_TEXT, json.dumps({
+                "type": "executing",
+                "data": {"node": "5", "prompt_id": "p-1"},
+            }).encode()),
+            (websocket.ABNF.OPCODE_BINARY, b"\x01\x00\x00\x00fake-preview"),
+            (websocket.ABNF.OPCODE_TEXT, json.dumps({
+                "type": "executing",
+                "data": {"node": None, "prompt_id": "p-1"},
+            }).encode()),
+        ]
+        mock_ws.recv_data = MagicMock(side_effect=events)
+
+        collected = list(self.client.ws_events("cid-1", "p-1"))
+        self.assertEqual(len(collected), 3)
+        self.assertEqual(collected[0]["type"], "execution_start")
+        self.assertEqual(collected[1]["type"], "executing")
+        self.assertEqual(collected[1]["data"]["node"], "5")
+        self.assertEqual(collected[2]["type"], "executing")
+        self.assertIsNone(collected[2]["data"]["node"])
+        mock_ws.close.assert_called_once()
+
+    @patch("websocket.create_connection")
+    def test_ws_events_filters_other_prompts(self, mock_ws_create: MagicMock) -> None:
+        import websocket
+
+        mock_ws = MagicMock()
+        mock_ws_create.return_value = mock_ws
+
+        events = [
+            (websocket.ABNF.OPCODE_TEXT, json.dumps({
+                "type": "executing",
+                "data": {"node": "1", "prompt_id": "other-prompt"},
+            }).encode()),
+            (websocket.ABNF.OPCODE_TEXT, json.dumps({
+                "type": "executing",
+                "data": {"node": None, "prompt_id": "p-1"},
+            }).encode()),
+        ]
+        mock_ws.recv_data = MagicMock(side_effect=events)
+
+        collected = list(self.client.ws_events("cid-1", "p-1"))
+        self.assertEqual(len(collected), 1)
+        self.assertIsNone(collected[0]["data"]["node"])
+
+    @patch("websocket.create_connection")
+    def test_ws_events_stops_on_error(self, mock_ws_create: MagicMock) -> None:
+        import websocket
+
+        mock_ws = MagicMock()
+        mock_ws_create.return_value = mock_ws
+
+        events = [
+            (websocket.ABNF.OPCODE_TEXT, json.dumps({
+                "type": "execution_error",
+                "data": {"prompt_id": "p-1", "exception_message": "boom"},
+            }).encode()),
+        ]
+        mock_ws.recv_data = MagicMock(side_effect=events)
+
+        collected = list(self.client.ws_events("cid-1", "p-1"))
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0]["type"], "execution_error")
+
+
+class NodesFlattenTests(unittest.TestCase):
+    def test_flatten_all(self) -> None:
+        from comfyui_skills_cli.commands.nodes import _flatten_nodes
+        rows = _flatten_nodes(SAMPLE_OBJECT_INFO)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["category"], "conditioning")
+        self.assertEqual(rows[1]["category"], "sampling")
+
+    def test_flatten_with_category_filter(self) -> None:
+        from comfyui_skills_cli.commands.nodes import _flatten_nodes
+        rows = _flatten_nodes(SAMPLE_OBJECT_INFO, "sampling")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["class_type"], "KSampler")
+
+    def test_flatten_with_nonexistent_category(self) -> None:
+        from comfyui_skills_cli.commands.nodes import _flatten_nodes
+        rows = _flatten_nodes(SAMPLE_OBJECT_INFO, "nonexistent")
+        self.assertEqual(len(rows), 0)
+
+
+class WsAvailableTests(unittest.TestCase):
+    def test_ws_available_true(self) -> None:
+        from comfyui_skills_cli.commands.run import _ws_available
+        result = _ws_available()
+        self.assertIsInstance(result, bool)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `comfyui-skill nodes list|info|search` command group exposing `/object_info`, enabling agents to discover available node classes, inspect input/output schemas, and search by name/category before importing workflows
- Add WebSocket real-time event streaming to `run` command — surfaces per-node execution status, progress (value/max), cache hits, and errors as NDJSON events instead of HTTP polling; auto-falls back to polling if `websocket-client` is unavailable
- Add `websocket-client>=1.0` to dependencies

## Test plan

- [ ] `comfyui-skill nodes list --json` returns all node classes with category/display_name
- [ ] `comfyui-skill nodes info KSampler --json` returns full input/output schema
- [ ] `comfyui-skill nodes search "sampler" --json` filters correctly
- [ ] `comfyui-skill run <skill> --output-format stream-json` emits real-time NDJSON events via WebSocket
- [ ] `comfyui-skill run <skill>` in text mode shows node names and progress percentages
- [ ] Uninstalling `websocket-client` causes graceful fallback to HTTP polling
- [ ] Unit tests in `tests/test_nodes_and_ws.py` pass
