### PR TITLE
feat: add server stats, jobs history, and partial execution support

### DIFF
--- a/comfyui_skills_cli/client.py
+++ b/comfyui_skills_cli/client.py
@@ -50,14 +50,21 @@ class ComfyUIClient:
         except (requests.RequestException, ValueError) as exc:
             return {"status": "offline", "error": str(exc)}
 
+    def get_system_stats(self) -> dict[str, Any]:
+        resp = self._get("/system_stats")
+        resp.raise_for_status()
+        return resp.json()
+
     # -- Prompt execution --
 
-    def queue_prompt(self, workflow: dict[str, Any], client_id: str | None = None) -> dict[str, Any]:
+    def queue_prompt(self, workflow: dict[str, Any], client_id: str | None = None, targets: list[str] | None = None) -> dict[str, Any]:
         cid = client_id or str(uuid.uuid4())
         payload: dict[str, Any] = {
             "prompt": workflow,
             "client_id": cid,
         }
+        if targets:
+            payload["partial_execution_targets"] = [[t] for t in targets]
         if self.comfy_api_key:
             payload["extra_data"] = {"api_key_comfy_org": self.comfy_api_key}
         resp = self._post("/prompt", json_data=payload)
@@ -72,6 +79,26 @@ class ComfyUIClient:
             return None
         data = resp.json()
         return data.get(prompt_id)
+
+    def get_history_list(self, max_items: int = 20, offset: int = 0) -> dict[str, Any]:
+        resp = self._get("/history", params={"max_items": max_items, "offset": offset})
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_jobs(self, status: str = "", limit: int = 20, offset: int = 0, sort_by: str = "created_at", sort_order: str = "desc") -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": limit, "offset": offset, "sort_by": sort_by, "sort_order": sort_order}
+        if status:
+            params["status"] = status
+        resp = self._get("/api/jobs", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_job(self, job_id: str) -> dict[str, Any] | None:
+        resp = self._get(f"/api/jobs/{job_id}")
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
 
     def get_queue(self) -> dict[str, Any]:
         resp = self._get("/queue")

--- a/comfyui_skills_cli/commands/jobs.py
+++ b/comfyui_skills_cli/commands/jobs.py
@@ -1,0 +1,108 @@
+"""comfyui-skill jobs — server-side job history."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..client import ComfyUIClient
+from ..config import get_base_dir, get_default_server_id, get_server, load_config
+from ..output import get_output_format, OutputFormat, output_error, output_result
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _build_client(ctx: typer.Context) -> ComfyUIClient:
+    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
+    config = load_config(base_dir)
+    server_id = ctx.obj.get("server") or get_default_server_id(config)
+    server_config = get_server(config, server_id)
+
+    if not server_config:
+        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
+
+    return ComfyUIClient(
+        server_url=server_config.get("url", "http://127.0.0.1:8188"),
+        auth=server_config.get("auth", ""),
+    )
+
+
+@app.command("list")
+def jobs_list(
+    ctx: typer.Context,
+    status: Optional[str] = typer.Option(None, "--status", help="Filter: pending, in_progress, completed, failed"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Max entries to return"),
+    sort: str = typer.Option("created_at", "--sort", help="Sort field"),
+):
+    """List jobs from the ComfyUI server."""
+    client = _build_client(ctx)
+    try:
+        data = client.get_jobs(status=status or "", limit=limit, sort_by=sort)
+    except Exception as exc:
+        output_error(ctx, "JOBS_FAILED", f"Failed to fetch jobs: {exc}")
+
+    fmt = get_output_format(ctx)
+    if fmt in (OutputFormat.JSON, OutputFormat.STREAM_JSON):
+        output_result(ctx, data)
+        return
+
+    # Text mode — render a table
+    jobs = data if isinstance(data, list) else data.get("jobs", data.get("items", []))
+    if not jobs:
+        Console().print("[dim]No jobs found.[/dim]")
+        return
+
+    table = Table(show_lines=True)
+    table.add_column("prompt_id")
+    table.add_column("status")
+    table.add_column("created_at")
+    table.add_column("duration")
+
+    for job in jobs:
+        prompt_id = str(job.get("prompt_id", job.get("id", "")))[:12]
+        job_status = job.get("status", "")
+        created = job.get("created_at", "")
+        duration = job.get("duration", job.get("execution_time", ""))
+        table.add_row(prompt_id, job_status, str(created), str(duration))
+
+    Console().print(table)
+
+
+@app.command("show")
+def jobs_show(
+    ctx: typer.Context,
+    prompt_id: str = typer.Argument(help="Prompt ID or job ID to look up"),
+):
+    """Show details of a specific job (falls back to history API)."""
+    client = _build_client(ctx)
+
+    # Try jobs API first, then history
+    try:
+        data = client.get_job(prompt_id)
+    except Exception:
+        data = None
+
+    if data is None:
+        try:
+            data = client.get_history(prompt_id)
+        except Exception as exc:
+            output_error(ctx, "JOBS_FAILED", f"Failed to fetch job: {exc}")
+
+    if data is None:
+        output_error(ctx, "NOT_FOUND", f'Job "{prompt_id}" not found.')
+
+    fmt = get_output_format(ctx)
+    if fmt in (OutputFormat.JSON, OutputFormat.STREAM_JSON):
+        output_result(ctx, data)
+        return
+
+    # Text mode
+    console = Console()
+    if isinstance(data, dict):
+        for key, value in data.items():
+            console.print(f"[bold]{key}:[/bold] {value}")
+    else:
+        console.print(data)

--- a/comfyui_skills_cli/commands/nodes.py
+++ b/comfyui_skills_cli/commands/nodes.py
@@ -33,14 +33,15 @@ def _build_client(ctx: typer.Context) -> ComfyUIClient:
 def _flatten_nodes(all_info: dict, category_filter: str = "") -> list[dict]:
     rows = []
     for class_type, info in all_info.items():
-        cat = info.get("category", "")
+        cat = info.get("category") or ""
+        display_name = info.get("display_name") or class_type
         if category_filter and category_filter.lower() != cat.lower():
             continue
         rows.append({
             "class_type": class_type,
-            "display_name": info.get("display_name", class_type),
+            "display_name": display_name,
             "category": cat,
-            "description": info.get("description", ""),
+            "description": info.get("description") or "",
         })
     rows.sort(key=lambda r: (r["category"].lower(), r["display_name"].lower()))
     return rows
@@ -162,14 +163,14 @@ def nodes_search(
     q = query.lower()
     rows = []
     for class_type, info in all_info.items():
-        display_name = info.get("display_name", class_type)
-        cat = info.get("category", "")
+        display_name = info.get("display_name") or class_type
+        cat = info.get("category") or ""
         if q in class_type.lower() or q in display_name.lower() or q in cat.lower():
             rows.append({
                 "class_type": class_type,
                 "display_name": display_name,
                 "category": cat,
-                "description": info.get("description", ""),
+                "description": info.get("description") or "",
             })
     rows.sort(key=lambda r: (r["category"].lower(), r["display_name"].lower()))
 

--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -38,6 +38,7 @@ def run_cmd(
     ctx: typer.Context,
     skill_id: str = typer.Argument(help="Skill ID: server_id/workflow_id or workflow_id"),
     args: str = typer.Option("{}", "--args", "-a", help="JSON parameters"),
+    only: str = typer.Option("", "--only", help="Comma-separated node IDs for partial execution (only run subgraph needed for these nodes)"),
 ):
     """Execute a skill (blocking — waits for completion)."""
     base_dir, server_id, workflow_id = _resolve_skill(ctx, skill_id)
@@ -48,9 +49,10 @@ def run_cmd(
     workflow = _inject_params(workflow_data, parameters, input_args)
 
     client_id = str(uuid.uuid4())
+    targets = [t.strip() for t in only.split(",") if t.strip()] if only else None
 
     try:
-        result = client.queue_prompt(workflow, client_id=client_id)
+        result = client.queue_prompt(workflow, client_id=client_id, targets=targets)
     except Exception as exc:
         output_error(ctx, "SUBMIT_FAILED", f"Failed to submit workflow: {exc}")
         return
@@ -235,6 +237,7 @@ def submit_cmd(
     ctx: typer.Context,
     skill_id: str = typer.Argument(help="Skill ID: server_id/workflow_id or workflow_id"),
     args: str = typer.Option("{}", "--args", "-a", help="JSON parameters"),
+    only: str = typer.Option("", "--only", help="Comma-separated node IDs for partial execution (only run subgraph needed for these nodes)"),
 ):
     """Submit a skill for execution (non-blocking — returns immediately)."""
     base_dir, server_id, workflow_id = _resolve_skill(ctx, skill_id)
@@ -243,9 +246,10 @@ def submit_cmd(
     input_args = _parse_args(ctx, args)
     parameters = _get_parameters(schema_data)
     workflow = _inject_params(workflow_data, parameters, input_args)
+    targets = [t.strip() for t in only.split(",") if t.strip()] if only else None
 
     try:
-        result = client.queue_prompt(workflow)
+        result = client.queue_prompt(workflow, targets=targets)
     except Exception as exc:
         output_error(ctx, "SUBMIT_FAILED", f"Failed to submit workflow: {exc}")
         return

--- a/comfyui_skills_cli/commands/server.py
+++ b/comfyui_skills_cli/commands/server.py
@@ -59,6 +59,66 @@ def server_status(
     })
 
 
+def _fmt_bytes(n: int) -> str:
+    """Format bytes as human-readable GB."""
+    return f"{n / (1024 ** 3):.1f} GB"
+
+
+@app.command("stats")
+def server_stats(
+    ctx: typer.Context,
+    server_id: str = typer.Argument("", help="Server ID (default: default server)"),
+    all_servers: bool = typer.Option(False, "--all", help="Query all enabled servers"),
+):
+    """Show detailed system stats (RAM, VRAM, versions) for a ComfyUI server."""
+    from ..output import get_output_format, is_machine_mode, OutputFormat
+    from rich.console import Console
+
+    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
+    config = load_config(base_dir)
+
+    if all_servers:
+        servers_list = [s for s in get_servers(config) if s.get("enabled", True)]
+    else:
+        sid = server_id or ctx.obj.get("server") or get_default_server_id(config)
+        server_config = get_server(config, sid)
+        if not server_config:
+            output_error(ctx, "SERVER_NOT_FOUND", f'Server "{sid}" not found.',
+                         hint="Run `comfy-skills server list` to see configured servers.")
+            return
+        servers_list = [server_config]
+
+    results = []
+    for srv in servers_list:
+        sid = srv.get("id", "")
+        client = ComfyUIClient(
+            server_url=srv.get("url", "http://127.0.0.1:8188"),
+            auth=srv.get("auth", ""),
+        )
+        try:
+            stats = client.get_system_stats()
+            results.append({"server_id": sid, **stats})
+        except Exception as exc:
+            results.append({"server_id": sid, "error": str(exc)})
+
+    if is_machine_mode(ctx):
+        output_result(ctx, results if all_servers else results[0])
+    else:
+        console = Console()
+        for entry in results:
+            if "error" in entry:
+                console.print(f"[bold]{entry['server_id']}:[/bold] [red]offline[/red] — {entry['error']}")
+                continue
+            system = entry.get("system", {})
+            devices = entry.get("devices", [])
+            console.print(f"[bold]Server:[/bold] {entry['server_id']}")
+            console.print(f"  OS: {system.get('os', '?')}  |  ComfyUI: {system.get('comfyui_version', '?')}  |  Python: {system.get('python_version', '?')}  |  PyTorch: {system.get('pytorch_version', '?')}")
+            console.print(f"  RAM: {_fmt_bytes(system.get('ram_total', 0))} total, {_fmt_bytes(system.get('ram_free', 0))} free")
+            for dev in devices:
+                console.print(f"  Device [{dev.get('name', '?')}]: VRAM {_fmt_bytes(dev.get('vram_total', 0))} total, {_fmt_bytes(dev.get('vram_free', 0))} free")
+            console.print()
+
+
 _INVALID_ID_PATTERN = re.compile(r"[/\\.\s]")
 
 

--- a/comfyui_skills_cli/main.py
+++ b/comfyui_skills_cli/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typer
 
 from . import __version__
-from .commands import cancel, config, deps, free, history, models, nodes, queue, run, server, skill, upload, workflow
+from .commands import cancel, config, deps, free, history, jobs, models, nodes, queue, run, server, skill, upload, workflow
 from .update_check import is_machine_output, maybe_notify_update
 
 app = typer.Typer(
@@ -49,7 +49,7 @@ def main(
 
 
 # Subcommand groups — each needs a callback to inherit parent context
-for sub_app in [config.app, deps.app, history.app, models.app, nodes.app, queue.app, server.app, workflow.app]:
+for sub_app in [config.app, deps.app, history.app, jobs.app, models.app, nodes.app, queue.app, server.app, workflow.app]:
     @sub_app.callback()
     def _pass_context(ctx: typer.Context):
         if ctx.parent and ctx.parent.obj:
@@ -61,6 +61,7 @@ app.add_typer(models.app, name="models", help="Discover available models")
 app.add_typer(nodes.app, name="nodes", help="Discover available ComfyUI nodes")
 app.add_typer(deps.app, name="deps", help="Manage dependencies")
 app.add_typer(history.app, name="history", help="Execution history")
+app.add_typer(jobs.app, name="jobs", help="Server-side job history")
 app.add_typer(queue.app, name="queue", help="View and manage execution queue")
 app.add_typer(server.app, name="server", help="Manage servers")
 app.add_typer(workflow.app, name="workflow", help="Manage workflows")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,99 @@
+"""Tests for server-side jobs/history client methods."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from comfyui_skills_cli.client import ComfyUIClient
+
+
+class GetHistoryListTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_history_list_default_params(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"abc123": {"status": {"completed": True}}}
+        mock_get.return_value = mock_resp
+
+        result = self.client.get_history_list()
+        self.assertEqual(result, {"abc123": {"status": {"completed": True}}})
+
+        call_kwargs = mock_get.call_args
+        self.assertIn("/history", call_kwargs.args[0])
+        self.assertEqual(call_kwargs.kwargs["params"], {"max_items": 20, "offset": 0})
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_history_list_custom_params(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {}
+        mock_get.return_value = mock_resp
+
+        self.client.get_history_list(max_items=5, offset=10)
+        call_kwargs = mock_get.call_args
+        self.assertEqual(call_kwargs.kwargs["params"], {"max_items": 5, "offset": 10})
+
+
+class GetJobsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_jobs_no_status_filter(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"jobs": []}
+        mock_get.return_value = mock_resp
+
+        result = self.client.get_jobs()
+        self.assertEqual(result, {"jobs": []})
+
+        call_kwargs = mock_get.call_args
+        self.assertIn("/api/jobs", call_kwargs.args[0])
+        params = call_kwargs.kwargs["params"]
+        self.assertNotIn("status", params)
+        self.assertEqual(params["limit"], 20)
+        self.assertEqual(params["sort_by"], "created_at")
+        self.assertEqual(params["sort_order"], "desc")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_jobs_with_status_filter(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"jobs": [{"id": "j1", "status": "completed"}]}
+        mock_get.return_value = mock_resp
+
+        result = self.client.get_jobs(status="completed", limit=5)
+        self.assertEqual(len(result["jobs"]), 1)
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs.kwargs["params"]
+        self.assertEqual(params["status"], "completed")
+        self.assertEqual(params["limit"], 5)
+
+
+class GetJobTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_job_found(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"id": "job-1", "status": "completed"}
+        mock_get.return_value = mock_resp
+
+        result = self.client.get_job("job-1")
+        self.assertEqual(result, {"id": "job-1", "status": "completed"})
+        self.assertIn("/api/jobs/job-1", mock_get.call_args.args[0])
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_job_not_found(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=404)
+        mock_get.return_value = mock_resp
+
+        result = self.client.get_job("nonexistent")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_partial_execution.py
+++ b/tests/test_partial_execution.py
@@ -1,0 +1,56 @@
+"""Tests for partial execution targets in queue_prompt."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from comfyui_skills_cli.client import ComfyUIClient
+
+
+class PartialExecutionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.post")
+    def test_queue_prompt_with_targets(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"prompt_id": "p-100"},
+        )
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        self.client.queue_prompt({"1": {}}, targets=["5", "8"])
+
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(payload["partial_execution_targets"], [["5"], ["8"]])
+
+    @patch("comfyui_skills_cli.client.requests.post")
+    def test_queue_prompt_without_targets(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"prompt_id": "p-101"},
+        )
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        self.client.queue_prompt({"1": {}}, targets=None)
+
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertNotIn("partial_execution_targets", payload)
+
+    @patch("comfyui_skills_cli.client.requests.post")
+    def test_queue_prompt_with_empty_targets(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"prompt_id": "p-102"},
+        )
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        self.client.queue_prompt({"1": {}}, targets=[])
+
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertNotIn("partial_execution_targets", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_stats.py
+++ b/tests/test_server_stats.py
@@ -1,0 +1,90 @@
+"""Tests for the server stats command and client method."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from comfyui_skills_cli.client import ComfyUIClient
+
+
+SAMPLE_STATS = {
+    "system": {
+        "os": "posix",
+        "ram_total": 68719476736,
+        "ram_free": 32000000000,
+        "comfyui_version": "v0.3.10",
+        "python_version": "3.11.5",
+        "pytorch_version": "2.1.0",
+        "embedded_python": False,
+    },
+    "devices": [
+        {
+            "name": "cuda:0",
+            "type": "cuda",
+            "index": 0,
+            "vram_total": 25769803776,
+            "vram_free": 20000000000,
+            "torch_vram_total": 25769803776,
+            "torch_vram_free": 22000000000,
+        }
+    ],
+}
+
+
+class GetSystemStatsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_system_stats_success(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = SAMPLE_STATS
+        mock_get.return_value = mock_resp
+
+        result = self.client.get_system_stats()
+
+        self.assertEqual(result, SAMPLE_STATS)
+        self.assertIn("/system_stats", mock_get.call_args.args[0])
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_get_system_stats_raises_on_error(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=500)
+        mock_resp.raise_for_status.side_effect = Exception("Server error")
+        mock_get.return_value = mock_resp
+
+        with self.assertRaises(Exception):
+            self.client.get_system_stats()
+
+
+class ServerStatsAllTests(unittest.TestCase):
+    """Test that --all queries multiple servers."""
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_all_queries_multiple_servers(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = SAMPLE_STATS
+        mock_get.return_value = mock_resp
+
+        # Create two clients (simulating what the command does)
+        clients = [
+            ComfyUIClient("http://server1:8188"),
+            ComfyUIClient("http://server2:8188"),
+        ]
+
+        results = []
+        for c in clients:
+            results.append(c.get_system_stats())
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["system"]["comfyui_version"], "v0.3.10")
+        self.assertEqual(results[1]["system"]["comfyui_version"], "v0.3.10")
+        # Verify both servers were called
+        self.assertEqual(mock_get.call_count, 2)
+        urls_called = [call.args[0] for call in mock_get.call_args_list]
+        self.assertIn("http://server1:8188/system_stats", urls_called)
+        self.assertIn("http://server2:8188/system_stats", urls_called)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **`server stats`**: expose `/system_stats` (VRAM/RAM/GPU name/ComfyUI version) so agents can route jobs to the best hardware. Supports `--all` for multi-server comparison.
- **`jobs list|show`**: expose server-side `/api/jobs` and `/history` with status filtering (`--status failed`), sorting, and pagination. Agents can now query "what failed in the last hour" or resume cross-session tasks.
- **`run/submit --only`**: pass `partial_execution_targets` to ComfyUI, enabling agents to re-run only the subgraph affected by a parameter change (e.g. re-sample without reloading the model).

All 44 unit tests pass.

## Test plan

- [ ] `comfyui-skill server stats --json` returns VRAM/RAM/device info
- [ ] `comfyui-skill server stats --all` queries all enabled servers
- [ ] `comfyui-skill jobs list --status failed --json` returns filtered results
- [ ] `comfyui-skill jobs show <prompt_id> --json` falls back from /api/jobs to /history
- [ ] `comfyui-skill run <skill> --only 5,8 --json` sends partial_execution_targets in payload
- [ ] `comfyui-skill submit <skill> --only 5 --json` sends partial_execution_targets
- [ ] Omitting --only does NOT include partial_execution_targets
