### PR TITLE
docs: add v0.2.7 changelog and update all READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## 0.2.7
+
+### New Commands
+
+- `nodes list / info / search` — discover available ComfyUI nodes, inspect input/output schemas, search by name or category
+- `server stats` — show VRAM, RAM, GPU, ComfyUI/Python/PyTorch versions (`--all` for multi-server comparison)
+- `server features` — query server capability flags
+- `jobs list / show` — server-side job history with status filtering and pagination
+- `logs show` — access ComfyUI server logs for error diagnosis
+- `templates list / subgraphs` — discover workflow templates and reusable subgraph components
+- `models embeddings` — list installed text embeddings
+- `models metadata` — inspect safetensors model metadata
+
+### New Flags
+
+- `run / submit --priority` — heap-based queue ordering (lower = first, negative = jump queue)
+- `run --validate` — dry-run workflow validation without GPU execution
+- `run / submit --only` — partial execution via `partial_execution_targets`
+- `upload --mask` — upload inpainting masks via `/upload/mask`
+
+### Improvements
+
+- `run` command now uses WebSocket streaming for real-time progress events instead of HTTP polling (auto-falls back to polling if unavailable)
+- `workflow import` now detects deprecated nodes and suggests replacements via `/node_replacements`
+- Added `websocket-client` to dependencies
+
+### Fixes
+
+- Handle `None` values in `/object_info` category and display_name fields
+- Fix double error output in `models metadata` when file not found

--- a/README.ja.md
+++ b/README.ja.md
@@ -107,11 +107,13 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 |----------|------|
 | `comfyui-skill list` | 利用可能なワークフローとパラメータを一覧表示 |
 | `comfyui-skill info <id>` | ワークフロー詳細とパラメータ schema を表示 |
-| `comfyui-skill run <id> --args '{...}'` | ワークフローを実行（同期） |
+| `comfyui-skill run <id> --args '{...}'` | ワークフローを実行（同期、リアルタイムWebSocketストリーミング） |
+| `comfyui-skill run <id> --validate` | ワークフローを実行せずに検証 |
 | `comfyui-skill submit <id> --args '{...}'` | ワークフローを送信（非同期） |
 | `comfyui-skill status <prompt_id>` | 実行状態を確認し、見つかった結果を表示 |
 | `comfyui-skill cancel <prompt_id>` | 実行中または待機中のジョブをキャンセル |
 | `comfyui-skill upload <file>` | ワークフローで使うためのファイルを ComfyUI にアップロード |
+| `comfyui-skill upload <file> --mask` | インペインティング用マスク画像のアップロード |
 | `comfyui-skill upload --from-output <prompt_id>` | 前回実行の出力を次のワークフロー入力として再利用 |
 
 ### キューとリソース管理
@@ -125,12 +127,17 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 | `comfyui-skill free --models` | モデルのみアンロード |
 | `comfyui-skill free --memory` | キャッシュメモリのみ解放 |
 
-### モデル探索
+### ノード・モデル探索
 
 | コマンド | 説明 |
 |----------|------|
+| `comfyui-skill nodes list` | カテゴリ別に利用可能な全ComfyUIノードを一覧表示 |
+| `comfyui-skill nodes info <class>` | ノードの入出力スキーマを表示 |
+| `comfyui-skill nodes search <query>` | 名前やカテゴリでノードを検索 |
 | `comfyui-skill models list` | 利用可能なモデルフォルダを一覧表示 |
 | `comfyui-skill models list <folder>` | 指定フォルダ内のモデルを一覧表示（例: `checkpoints`, `loras`） |
+| `comfyui-skill models embeddings` | 利用可能なテキスト埋め込みを一覧表示 |
+| `comfyui-skill models metadata <folder> <file>` | safetensorsモデルのメタデータを表示 |
 
 ### ワークフロー管理
 
@@ -151,6 +158,8 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 | `comfyui-skill server add --id <id> --url <url>` | 新しいサーバーを追加 |
 | `comfyui-skill server enable/disable <id>` | サーバーの有効/無効を切り替え |
 | `comfyui-skill server remove <id>` | サーバーを削除 |
+| `comfyui-skill server stats` | VRAM、RAM、GPU情報を表示（`--all`で全サーバー） |
+| `comfyui-skill server features` | サーバー機能フラグを表示 |
 
 ### 依存関係管理
 
@@ -169,6 +178,11 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 | `comfyui-skill config import <path>` | 設定バンドルをインポート（`--dry-run` 対応） |
 | `comfyui-skill history list <id>` | 実行履歴を一覧表示 |
 | `comfyui-skill history show <id> <run_id>` | 特定の実行詳細を表示 |
+| `comfyui-skill jobs list` | サーバー側ジョブ履歴を表示（`--status`でフィルタ） |
+| `comfyui-skill jobs show <prompt_id>` | 特定ジョブの詳細を表示 |
+| `comfyui-skill logs show` | ComfyUIサーバーログを表示 |
+| `comfyui-skill templates list` | カスタムノードのワークフローテンプレートを一覧表示 |
+| `comfyui-skill templates subgraphs` | 再利用可能なサブグラフコンポーネントを一覧表示 |
 
 ### グローバルオプション
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,13 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 |---------|-------------|
 | `comfyui-skill list` | List all available workflows with parameters |
 | `comfyui-skill info <id>` | Show workflow details and parameter schema |
-| `comfyui-skill run <id> --args '{...}'` | Execute a workflow (blocking) |
+| `comfyui-skill run <id> --args '{...}'` | Execute a workflow (blocking, real-time WebSocket streaming) |
+| `comfyui-skill run <id> --validate` | Validate workflow without executing |
 | `comfyui-skill submit <id> --args '{...}'` | Submit a workflow (non-blocking) |
 | `comfyui-skill status <prompt_id>` | Check execution status and show discovered results |
 | `comfyui-skill cancel <prompt_id>` | Cancel a running or queued job |
 | `comfyui-skill upload <file>` | Upload a file to ComfyUI for use in workflows |
+| `comfyui-skill upload <file> --mask` | Upload a mask image for inpainting workflows |
 | `comfyui-skill upload --from-output <prompt_id>` | Chain a previous run's output as input for the next workflow |
 
 ### Queue & Resource Management
@@ -128,12 +130,17 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 | `comfyui-skill free --models` | Unload models only |
 | `comfyui-skill free --memory` | Free cached memory only |
 
-### Model Discovery
+### Node & Model Discovery
 
 | Command | Description |
 |---------|-------------|
+| `comfyui-skill nodes list` | List all available ComfyUI nodes by category |
+| `comfyui-skill nodes info <class>` | Show node input/output schema |
+| `comfyui-skill nodes search <query>` | Search nodes by name or category |
 | `comfyui-skill models list` | List all available model folders |
 | `comfyui-skill models list <folder>` | List models in a specific folder (e.g., `checkpoints`, `loras`) |
+| `comfyui-skill models embeddings` | List available text embeddings |
+| `comfyui-skill models metadata <folder> <file>` | Show safetensors model metadata |
 
 ### Workflow Management
 
@@ -151,6 +158,8 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 |---------|-------------|
 | `comfyui-skill server list` | List all configured servers |
 | `comfyui-skill server status` | Check if ComfyUI server is online |
+| `comfyui-skill server stats` | Show VRAM, RAM, GPU info (`--all` for multi-server) |
+| `comfyui-skill server features` | Show server capability flags |
 | `comfyui-skill server add --id <id> --url <url>` | Add a new server |
 | `comfyui-skill server enable/disable <id>` | Toggle server availability |
 | `comfyui-skill server remove <id>` | Remove a server |
@@ -172,6 +181,11 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 | `comfyui-skill config import <path>` | Import config bundle (supports `--dry-run`) |
 | `comfyui-skill history list <id>` | List execution history |
 | `comfyui-skill history show <id> <run_id>` | Show details of a specific run |
+| `comfyui-skill jobs list` | List server-side job history (`--status` to filter) |
+| `comfyui-skill jobs show <prompt_id>` | Show details of a specific job |
+| `comfyui-skill logs show` | Show recent ComfyUI server logs |
+| `comfyui-skill templates list` | List workflow templates from custom nodes |
+| `comfyui-skill templates subgraphs` | List reusable subgraph components |
 
 ### Global Options
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -107,11 +107,13 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 |------|------|
 | `comfyui-skill list` | 列出所有可用工作流程與參數 |
 | `comfyui-skill info <id>` | 查看工作流程詳情與參數 schema |
-| `comfyui-skill run <id> --args '{...}'` | 執行工作流程（阻塞） |
+| `comfyui-skill run <id> --args '{...}'` | 執行工作流程（阻塞），即時 WebSocket 串流輸出 |
+| `comfyui-skill run <id> --validate` | 驗證工作流但不執行 |
 | `comfyui-skill submit <id> --args '{...}'` | 提交工作流程（非阻塞） |
 | `comfyui-skill status <prompt_id>` | 查詢執行狀態並顯示已找到的結果 |
 | `comfyui-skill cancel <prompt_id>` | 取消執行中或排隊中的任務 |
 | `comfyui-skill upload <file>` | 上傳檔案到 ComfyUI，供工作流程使用 |
+| `comfyui-skill upload <file> --mask` | 上傳 inpainting 遮罩圖片 |
 | `comfyui-skill upload --from-output <prompt_id>` | 將前一次執行的輸出串接成下一個工作流程的輸入 |
 
 ### 佇列與資源管理
@@ -125,12 +127,17 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 | `comfyui-skill free --models` | 只卸載模型 |
 | `comfyui-skill free --memory` | 只釋放快取記憶體 |
 
-### 模型探索
+### 節點與模型探索
 
 | 命令 | 說明 |
 |------|------|
+| `comfyui-skill nodes list` | 依分類列出所有可用的 ComfyUI 節點 |
+| `comfyui-skill nodes info <class>` | 查看節點輸入/輸出 schema |
+| `comfyui-skill nodes search <query>` | 依名稱或分類搜尋節點 |
 | `comfyui-skill models list` | 列出所有可用模型資料夾 |
 | `comfyui-skill models list <folder>` | 列出指定資料夾中的模型（例如 `checkpoints`、`loras`） |
+| `comfyui-skill models embeddings` | 列出可用的文字嵌入 |
+| `comfyui-skill models metadata <folder> <file>` | 查看 safetensors 模型中繼資料 |
 
 ### 工作流程管理
 
@@ -151,6 +158,8 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 | `comfyui-skill server add --id <id> --url <url>` | 新增伺服器 |
 | `comfyui-skill server enable/disable <id>` | 啟用或停用伺服器 |
 | `comfyui-skill server remove <id>` | 移除伺服器 |
+| `comfyui-skill server stats` | 查看 VRAM、RAM、GPU 資訊（`--all` 查看所有伺服器） |
+| `comfyui-skill server features` | 查看伺服器功能旗標 |
 
 ### 依賴管理
 
@@ -169,6 +178,11 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 | `comfyui-skill config import <path>` | 匯入設定（支援 `--dry-run`） |
 | `comfyui-skill history list <id>` | 查看執行歷史 |
 | `comfyui-skill history show <id> <run_id>` | 查看單次執行詳情 |
+| `comfyui-skill jobs list` | 查看伺服器端任務歷史（`--status` 可篩選） |
+| `comfyui-skill jobs show <prompt_id>` | 查看特定任務詳情 |
+| `comfyui-skill logs show` | 查看 ComfyUI 伺服器日誌 |
+| `comfyui-skill templates list` | 列出自訂節點提供的工作流範本 |
+| `comfyui-skill templates subgraphs` | 列出可重複使用的子工作流元件 |
 
 ### 全域選項
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -107,11 +107,13 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 |------|------|
 | `comfyui-skill list` | 列出所有可用工作流及参数 |
 | `comfyui-skill info <id>` | 查看工作流详情和参数 schema |
-| `comfyui-skill run <id> --args '{...}'` | 执行工作流（阻塞） |
+| `comfyui-skill run <id> --args '{...}'` | 执行工作流（阻塞，实时 WebSocket 流式输出） |
+| `comfyui-skill run <id> --validate` | 验证工作流但不执行 |
 | `comfyui-skill submit <id> --args '{...}'` | 提交工作流（非阻塞） |
 | `comfyui-skill status <prompt_id>` | 查询执行状态并显示已发现的结果 |
 | `comfyui-skill cancel <prompt_id>` | 取消运行中或排队中的任务 |
 | `comfyui-skill upload <file>` | 上传文件到 ComfyUI 供工作流使用 |
+| `comfyui-skill upload <file> --mask` | 上传 inpainting 蒙版图片 |
 | `comfyui-skill upload --from-output <prompt_id>` | 将上次运行的输出作为下一个工作流的输入 |
 
 ### 队列与资源管理
@@ -125,12 +127,17 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | `comfyui-skill free --models` | 仅卸载模型 |
 | `comfyui-skill free --memory` | 仅释放缓存 |
 
-### 模型发现
+### 节点与模型发现
 
 | 命令 | 说明 |
 |------|------|
+| `comfyui-skill nodes list` | 按分类列出所有可用的 ComfyUI 节点 |
+| `comfyui-skill nodes info <class>` | 查看节点输入/输出 schema |
+| `comfyui-skill nodes search <query>` | 按名称或分类搜索节点 |
 | `comfyui-skill models list` | 列出所有模型文件夹 |
 | `comfyui-skill models list <folder>` | 列出指定文件夹中的模型（如 `checkpoints`、`loras`） |
+| `comfyui-skill models embeddings` | 列出可用的文本嵌入 |
+| `comfyui-skill models metadata <folder> <file>` | 查看 safetensors 模型元数据 |
 
 ### 工作流管理
 
@@ -151,6 +158,8 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | `comfyui-skill server add --id <id> --url <url>` | 添加新服务器 |
 | `comfyui-skill server enable/disable <id>` | 启用/禁用服务器 |
 | `comfyui-skill server remove <id>` | 移除服务器 |
+| `comfyui-skill server stats` | 查看 VRAM、RAM、GPU 信息（`--all` 查看所有服务器） |
+| `comfyui-skill server features` | 查看服务器功能标志 |
 
 ### 依赖管理
 
@@ -169,6 +178,11 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | `comfyui-skill config import <path>` | 导入配置（支持 `--dry-run`） |
 | `comfyui-skill history list <id>` | 查看执行历史 |
 | `comfyui-skill history show <id> <run_id>` | 查看单次运行详情 |
+| `comfyui-skill jobs list` | 查看服务端任务历史（`--status` 可过滤） |
+| `comfyui-skill jobs show <prompt_id>` | 查看特定任务详情 |
+| `comfyui-skill logs show` | 查看 ComfyUI 服务器日志 |
+| `comfyui-skill templates list` | 列出自定义节点提供的工作流模板 |
+| `comfyui-skill templates subgraphs` | 列出可复用的子工作流组件 |
 
 ### 全局选项
 
@@ -272,10 +286,6 @@ comfyui-skill deps install local/my-workflow --all --json
 
 ## 相关资源
 
-<<<<<<< HEAD
 - [ComfyUI Skills OpenClaw](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw) — 主仓库（Skills 定义）
 - [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — 本 CLI 调度的后端
 - [Typer](https://typer.tiangolo.com/) — 本项目使用的 CLI 框架
-=======
-基于 [Typer](https://typer.tiangolo.com/) 构建，与 [comfy-cli](https://github.com/Comfy-Org/comfy-cli) 使用相同框架。未来计划作为 `comfy skills` 子命令集成。
->>>>>>> 246e194 (docs: add zh-TW and ja readmes)


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` covering all v0.2.7 changes (new commands, flags, improvements, fixes)
- Update command tables in all 4 READMEs (en, zh, zh-TW, ja) with new commands: nodes, jobs, logs, templates, server stats/features, models embeddings/metadata, upload --mask, run --validate
- Fix stale merge conflict markers in README.zh.md

## Test plan

- [ ] Verify CHANGELOG.md renders correctly on GitHub
- [ ] Verify all 4 README command tables match the actual CLI `--help` output
