### PR TITLE
fix: extract shared build_client and fix missing return after output_error

### DIFF
--- a/comfyui_skills_cli/commands/jobs.py
+++ b/comfyui_skills_cli/commands/jobs.py
@@ -8,26 +8,10 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from ..client import ComfyUIClient
-from ..config import get_base_dir, get_default_server_id, get_server, load_config
 from ..output import get_output_format, OutputFormat, output_error, output_result
+from ..utils import build_client
 
 app = typer.Typer(no_args_is_help=True)
-
-
-def _build_client(ctx: typer.Context) -> ComfyUIClient:
-    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
-    config = load_config(base_dir)
-    server_id = ctx.obj.get("server") or get_default_server_id(config)
-    server_config = get_server(config, server_id)
-
-    if not server_config:
-        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
-
-    return ComfyUIClient(
-        server_url=server_config.get("url", "http://127.0.0.1:8188"),
-        auth=server_config.get("auth", ""),
-    )
 
 
 @app.command("list")
@@ -38,11 +22,12 @@ def jobs_list(
     sort: str = typer.Option("created_at", "--sort", help="Sort field"),
 ):
     """List jobs from the ComfyUI server."""
-    client = _build_client(ctx)
+    client, _ = build_client(ctx)
     try:
         data = client.get_jobs(status=status or "", limit=limit, sort_by=sort)
     except Exception as exc:
         output_error(ctx, "JOBS_FAILED", f"Failed to fetch jobs: {exc}")
+        return
 
     fmt = get_output_format(ctx)
     if fmt in (OutputFormat.JSON, OutputFormat.STREAM_JSON):
@@ -77,7 +62,7 @@ def jobs_show(
     prompt_id: str = typer.Argument(help="Prompt ID or job ID to look up"),
 ):
     """Show details of a specific job (falls back to history API)."""
-    client = _build_client(ctx)
+    client, _ = build_client(ctx)
 
     # Try jobs API first, then history
     try:
@@ -90,6 +75,7 @@ def jobs_show(
             data = client.get_history(prompt_id)
         except Exception as exc:
             output_error(ctx, "JOBS_FAILED", f"Failed to fetch job: {exc}")
+            return
 
     if data is None:
         output_error(ctx, "NOT_FOUND", f'Job "{prompt_id}" not found.')

--- a/comfyui_skills_cli/commands/logs.py
+++ b/comfyui_skills_cli/commands/logs.py
@@ -4,27 +4,10 @@ from __future__ import annotations
 
 import typer
 
-from ..client import ComfyUIClient
-from ..config import get_base_dir, get_default_server_id, get_server, load_config
 from ..output import output_error, output_result
+from ..utils import build_client
 
 app = typer.Typer(no_args_is_help=True)
-
-
-def _build_client(ctx: typer.Context) -> tuple[ComfyUIClient, str]:
-    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
-    config = load_config(base_dir)
-    server_id = ctx.obj.get("server") or get_default_server_id(config)
-    server_config = get_server(config, server_id)
-
-    if not server_config:
-        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
-
-    client = ComfyUIClient(
-        server_url=server_config.get("url", "http://127.0.0.1:8188"),
-        auth=server_config.get("auth", ""),
-    )
-    return client, server_id
 
 
 @app.command("show")
@@ -33,7 +16,7 @@ def logs_show(
     lines: int = typer.Option(50, "--lines", "-n", help="Number of recent log lines to show"),
 ):
     """Show recent ComfyUI server logs."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
 
     try:
         data = client.get_logs()
@@ -47,3 +30,4 @@ def logs_show(
         })
     except Exception as exc:
         output_error(ctx, "LOGS_FAILED", f"Failed to fetch logs: {exc}")
+        return

--- a/comfyui_skills_cli/commands/models.py
+++ b/comfyui_skills_cli/commands/models.py
@@ -6,27 +6,10 @@ from typing import Optional
 
 import typer
 
-from ..client import ComfyUIClient
-from ..config import get_base_dir, get_default_server_id, get_server, load_config
 from ..output import output_error, output_result
+from ..utils import build_client
 
 app = typer.Typer(no_args_is_help=True)
-
-
-def _build_client(ctx: typer.Context) -> tuple[ComfyUIClient, str]:
-    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
-    config = load_config(base_dir)
-    server_id = ctx.obj.get("server") or get_default_server_id(config)
-    server_config = get_server(config, server_id)
-
-    if not server_config:
-        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
-
-    client = ComfyUIClient(
-        server_url=server_config.get("url", "http://127.0.0.1:8188"),
-        auth=server_config.get("auth", ""),
-    )
-    return client, server_id
 
 
 @app.command("list")
@@ -35,7 +18,7 @@ def models_list(
     folder: Optional[str] = typer.Argument(None, help="Model folder (e.g., checkpoints, loras, vae). Omit to list all folders."),
 ):
     """List available models. Specify a folder to see its contents, or omit to list all folders."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
 
     try:
         if folder:
@@ -54,17 +37,19 @@ def models_list(
             })
     except Exception as exc:
         output_error(ctx, "MODELS_FAILED", f"Failed to list models: {exc}")
+        return
 
 
 @app.command("embeddings")
 def models_embeddings(ctx: typer.Context):
     """List available text embeddings."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
     try:
         embeddings = client.get_embeddings()
         output_result(ctx, {"server_id": server_id, "embeddings": embeddings, "count": len(embeddings)})
     except Exception as exc:
         output_error(ctx, "EMBEDDINGS_FAILED", f"Failed to list embeddings: {exc}")
+        return
 
 
 @app.command("metadata")
@@ -74,7 +59,7 @@ def models_metadata(
     filename: str = typer.Argument(help="Model filename"),
 ):
     """Show safetensors metadata for a model file."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
     try:
         data = client.get_model_metadata(folder, filename)
     except Exception as exc:

--- a/comfyui_skills_cli/commands/nodes.py
+++ b/comfyui_skills_cli/commands/nodes.py
@@ -8,26 +8,10 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from ..client import ComfyUIClient
-from ..config import get_base_dir, get_default_server_id, get_server, load_config
 from ..output import get_output_format, OutputFormat, output_error, output_result
+from ..utils import build_client
 
 app = typer.Typer(no_args_is_help=True)
-
-
-def _build_client(ctx: typer.Context) -> ComfyUIClient:
-    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
-    config = load_config(base_dir)
-    server_id = ctx.obj.get("server") or get_default_server_id(config)
-    server_config = get_server(config, server_id)
-
-    if not server_config:
-        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
-
-    return ComfyUIClient(
-        server_url=server_config.get("url", "http://127.0.0.1:8188"),
-        auth=server_config.get("auth", ""),
-    )
 
 
 def _flatten_nodes(all_info: dict, category_filter: str = "") -> list[dict]:
@@ -64,11 +48,12 @@ def nodes_list(
     category: Optional[str] = typer.Option(None, "--category", "-c", help="Filter by category"),
 ):
     """List all available node classes, grouped by category."""
-    client = _build_client(ctx)
+    client, _ = build_client(ctx)
     try:
         all_info = client.get_object_info()
     except Exception as exc:
         output_error(ctx, "NODES_FAILED", f"Failed to fetch nodes: {exc}")
+        return
 
     rows = _flatten_nodes(all_info, category or "")
 
@@ -85,11 +70,12 @@ def nodes_info(
     node_class: str = typer.Argument(help="Node class name (e.g. KSampler)"),
 ):
     """Show full details of a single node class."""
-    client = _build_client(ctx)
+    client, _ = build_client(ctx)
     try:
         info = client.get_object_info_node(node_class)
     except Exception as exc:
         output_error(ctx, "NODES_FAILED", f"Failed to fetch node info: {exc}")
+        return
 
     if not info:
         output_error(ctx, "NODE_NOT_FOUND", f'Node class "{node_class}" not found.')
@@ -154,11 +140,12 @@ def nodes_search(
     query: str = typer.Argument(help="Search query (substring match)"),
 ):
     """Fuzzy search across node names, display names, and categories."""
-    client = _build_client(ctx)
+    client, _ = build_client(ctx)
     try:
         all_info = client.get_object_info()
     except Exception as exc:
         output_error(ctx, "NODES_FAILED", f"Failed to fetch nodes: {exc}")
+        return
 
     q = query.lower()
     rows = []

--- a/comfyui_skills_cli/commands/queue.py
+++ b/comfyui_skills_cli/commands/queue.py
@@ -6,33 +6,16 @@ from typing import List
 
 import typer
 
-from ..client import ComfyUIClient
-from ..config import get_base_dir, get_default_server_id, get_server, load_config
 from ..output import output_error, output_result
+from ..utils import build_client
 
 app = typer.Typer(no_args_is_help=True)
-
-
-def _build_client(ctx: typer.Context) -> tuple[ComfyUIClient, str]:
-    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
-    config = load_config(base_dir)
-    server_id = ctx.obj.get("server") or get_default_server_id(config)
-    server_config = get_server(config, server_id)
-
-    if not server_config:
-        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
-
-    client = ComfyUIClient(
-        server_url=server_config.get("url", "http://127.0.0.1:8188"),
-        auth=server_config.get("auth", ""),
-    )
-    return client, server_id
 
 
 @app.command("list")
 def queue_list(ctx: typer.Context):
     """Show running and pending jobs in the queue."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
 
     try:
         queue = client.get_queue()
@@ -53,18 +36,20 @@ def queue_list(ctx: typer.Context):
         })
     except Exception as exc:
         output_error(ctx, "QUEUE_FAILED", f"Failed to get queue: {exc}")
+        return
 
 
 @app.command("clear")
 def queue_clear(ctx: typer.Context):
     """Clear all pending jobs from the queue (does not stop running jobs)."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
 
     try:
         client.queue_clear()
         output_result(ctx, {"status": "cleared", "server_id": server_id})
     except Exception as exc:
         output_error(ctx, "QUEUE_FAILED", f"Failed to clear queue: {exc}")
+        return
 
 
 @app.command("delete")
@@ -73,10 +58,11 @@ def queue_delete(
     prompt_ids: List[str] = typer.Argument(help="Prompt IDs to remove from queue"),
 ):
     """Remove specific jobs from the pending queue."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
 
     try:
         client.queue_delete(prompt_ids)
         output_result(ctx, {"status": "deleted", "prompt_ids": prompt_ids, "server_id": server_id})
     except Exception as exc:
         output_error(ctx, "QUEUE_FAILED", f"Failed to delete from queue: {exc}")
+        return

--- a/comfyui_skills_cli/commands/templates.py
+++ b/comfyui_skills_cli/commands/templates.py
@@ -4,27 +4,10 @@ from __future__ import annotations
 
 import typer
 
-from ..client import ComfyUIClient
-from ..config import get_base_dir, get_default_server_id, get_server, load_config
 from ..output import output_error, output_result
+from ..utils import build_client
 
 app = typer.Typer(no_args_is_help=True)
-
-
-def _build_client(ctx: typer.Context) -> tuple[ComfyUIClient, str]:
-    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
-    config = load_config(base_dir)
-    server_id = ctx.obj.get("server") or get_default_server_id(config)
-    server_config = get_server(config, server_id)
-
-    if not server_config:
-        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
-
-    client = ComfyUIClient(
-        server_url=server_config.get("url", "http://127.0.0.1:8188"),
-        auth=server_config.get("auth", ""),
-    )
-    return client, server_id
 
 
 @app.command("list")
@@ -32,7 +15,7 @@ def templates_list(
     ctx: typer.Context,
 ):
     """List workflow templates from custom nodes."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
 
     try:
         data = client.get_workflow_templates()
@@ -43,6 +26,7 @@ def templates_list(
         })
     except Exception as exc:
         output_error(ctx, "TEMPLATES_FAILED", f"Failed to fetch templates: {exc}")
+        return
 
 
 @app.command("subgraphs")
@@ -50,7 +34,7 @@ def templates_subgraphs(
     ctx: typer.Context,
 ):
     """List reusable subgraph components."""
-    client, server_id = _build_client(ctx)
+    client, server_id = build_client(ctx)
 
     try:
         data = client.get_subgraphs()
@@ -61,3 +45,4 @@ def templates_subgraphs(
         })
     except Exception as exc:
         output_error(ctx, "SUBGRAPHS_FAILED", f"Failed to fetch subgraphs: {exc}")
+        return

--- a/comfyui_skills_cli/utils.py
+++ b/comfyui_skills_cli/utils.py
@@ -1,0 +1,26 @@
+"""Shared utilities for command modules."""
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .client import ComfyUIClient
+from .config import get_base_dir, get_default_server_id, get_server, load_config
+from .output import output_error
+
+
+def build_client(ctx: typer.Context) -> tuple[ComfyUIClient, str]:
+    """Build a ComfyUIClient from context. Exits on error."""
+    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
+    config = load_config(base_dir)
+    server_id = ctx.obj.get("server") or get_default_server_id(config)
+    server_config = get_server(config, server_id)
+    if not server_config:
+        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{server_id}" not found.')
+        raise typer.Exit(code=1)  # Safety net — output_error already exits, but be explicit
+    client = ComfyUIClient(
+        server_url=server_config.get("url", "http://127.0.0.1:8188"),
+        auth=server_config.get("auth", ""),
+    )
+    return client, server_id


### PR DESCRIPTION
## Summary

- Extract duplicated `_build_client()` (7 copies across 6 command files) into shared `utils.build_client()`
- Add explicit `raise typer.Exit(code=1)` safety net after `output_error()` to prevent continued execution with None server config

## Test plan

- [ ] All 44 unit tests pass
- [ ] `comfyui-skill --json --dir /tmp/comfyui-test-project server status` still works
- [ ] Invalid server ID returns clean error instead of crash
