### PR TITLE
fix: add return after output_error in exception handlers

### DIFF
--- a/comfyui_skills_cli/commands/cancel.py
+++ b/comfyui_skills_cli/commands/cancel.py
@@ -49,3 +49,4 @@ def cancel_cmd(
 
     except Exception as exc:
         output_error(ctx, "CANCEL_FAILED", f"Failed to cancel job: {exc}")
+        return

--- a/comfyui_skills_cli/commands/free.py
+++ b/comfyui_skills_cli/commands/free.py
@@ -44,3 +44,4 @@ def free_cmd(
         output_result(ctx, {"status": "ok", "actions": actions, "server_id": server_id})
     except Exception as exc:
         output_error(ctx, "FREE_FAILED", f"Failed to free memory: {exc}")
+        return

--- a/comfyui_skills_cli/commands/server.py
+++ b/comfyui_skills_cli/commands/server.py
@@ -232,6 +232,7 @@ def server_features(
         output_result(ctx, {"server_id": sid, "features": features})
     except Exception as exc:
         output_error(ctx, "SERVER_ERROR", f"Failed to fetch features: {exc}")
+        return
 
 
 def _toggle_server(ctx: typer.Context, server_id: str, enabled: bool) -> None:

--- a/comfyui_skills_cli/commands/upload.py
+++ b/comfyui_skills_cli/commands/upload.py
@@ -78,6 +78,7 @@ def _upload_local_file(
         })
     except Exception as exc:
         output_error(ctx, "UPLOAD_FAILED", f"Upload failed: {exc}")
+        return
 
 
 def _upload_from_output(
@@ -143,3 +144,4 @@ def _upload_from_output(
 
     except Exception as exc:
         output_error(ctx, "CHAIN_FAILED", f"Failed to chain output: {exc}")
+        return


### PR DESCRIPTION
Add explicit return statements after output_error() calls inside except blocks to prevent continued execution with undefined variables.