### PR TITLE
fix: prevent path traversal in storage and workflow commands

### DIFF
--- a/comfyui_skills_cli/commands/workflow.py
+++ b/comfyui_skills_cli/commands/workflow.py
@@ -13,6 +13,7 @@ import typer
 from ..client import ComfyUIClient
 from ..config import get_base_dir, get_default_server_id, get_server, load_config
 from ..output import output_error, output_event, output_result
+from ..storage import _safe_path
 
 app = typer.Typer()
 
@@ -469,7 +470,7 @@ def _import_from_file(
         return
 
     # Write files
-    workflow_dir = base_dir / "data" / server_id / workflow_id
+    workflow_dir = _safe_path(base_dir, server_id, workflow_id)
     workflow_dir.mkdir(parents=True, exist_ok=True)
 
     with open(workflow_dir / "workflow.json", "w", encoding="utf-8") as f:
@@ -604,7 +605,7 @@ def _import_from_server(
         workflow_id = _suggest_workflow_id(api_data, filename)
         parameters = _extract_schema(api_data, media_type)
 
-        workflow_dir = base_dir / "data" / server_id / workflow_id
+        workflow_dir = _safe_path(base_dir, server_id, workflow_id)
         workflow_dir.mkdir(parents=True, exist_ok=True)
 
         with open(workflow_dir / "workflow.json", "w", encoding="utf-8") as f:
@@ -674,7 +675,11 @@ def workflow_delete(
     base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
     server_id, workflow_id = _parse_skill_id(ctx, skill_id)
 
-    workflow_dir = base_dir / "data" / server_id / workflow_id
+    try:
+        workflow_dir = _safe_path(base_dir, server_id, workflow_id)
+    except ValueError:
+        output_error(ctx, "INVALID_PATH", f'Invalid skill ID: "{skill_id}"')
+        return
     if not workflow_dir.is_dir():
         output_error(ctx, "SKILL_NOT_FOUND", f'Workflow "{skill_id}" not found.')
         return
@@ -692,7 +697,12 @@ def _toggle_workflow(ctx: typer.Context, skill_id: str, enabled: bool) -> None:
     base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
     server_id, workflow_id = _parse_skill_id(ctx, skill_id)
 
-    schema_path = base_dir / "data" / server_id / workflow_id / "schema.json"
+    try:
+        workflow_dir = _safe_path(base_dir, server_id, workflow_id)
+    except ValueError:
+        output_error(ctx, "INVALID_PATH", f'Invalid skill ID: "{skill_id}"')
+        return
+    schema_path = workflow_dir / "schema.json"
     if not schema_path.exists():
         output_error(ctx, "SKILL_NOT_FOUND", f'Workflow "{skill_id}" not found.')
         return

--- a/comfyui_skills_cli/storage.py
+++ b/comfyui_skills_cli/storage.py
@@ -7,8 +7,20 @@ from pathlib import Path
 from typing import Any
 
 
+def _safe_path(base_dir: Path, server_id: str, workflow_id: str) -> Path:
+    """Construct and validate a workflow directory path. Raises ValueError on traversal."""
+    target = (base_dir / "data" / server_id / workflow_id).resolve()
+    safe_root = (base_dir / "data").resolve()
+    if not str(target).startswith(str(safe_root) + "/") and target != safe_root:
+        raise ValueError(f"Invalid path: {server_id}/{workflow_id}")
+    return target
+
+
 def list_workflows(base_dir: Path, server_id: str) -> list[dict[str, Any]]:
-    data_dir = base_dir / "data" / server_id
+    data_dir = (base_dir / "data" / server_id).resolve()
+    safe_root = (base_dir / "data").resolve()
+    if not str(data_dir).startswith(str(safe_root) + "/") and data_dir != safe_root:
+        return []
     if not data_dir.exists():
         return []
 
@@ -31,7 +43,7 @@ def list_workflows(base_dir: Path, server_id: str) -> list[dict[str, Any]]:
 
 
 def get_workflow_detail(base_dir: Path, server_id: str, workflow_id: str) -> dict[str, Any] | None:
-    workflow_dir = base_dir / "data" / server_id / workflow_id
+    workflow_dir = _safe_path(base_dir, server_id, workflow_id)
     if not workflow_dir.is_dir():
         return None
 
@@ -53,14 +65,14 @@ def get_workflow_detail(base_dir: Path, server_id: str, workflow_id: str) -> dic
 
 
 def get_workflow_data(base_dir: Path, server_id: str, workflow_id: str) -> dict[str, Any] | None:
-    path = base_dir / "data" / server_id / workflow_id / "workflow.json"
+    path = _safe_path(base_dir, server_id, workflow_id) / "workflow.json"
     if not path.exists():
         return None
     return _load_json(path)
 
 
 def get_schema(base_dir: Path, server_id: str, workflow_id: str) -> dict[str, Any] | None:
-    path = base_dir / "data" / server_id / workflow_id / "schema.json"
+    path = _safe_path(base_dir, server_id, workflow_id) / "schema.json"
     if not path.exists():
         return None
     return _load_json(path)

--- a/comfyui_skills_cli/storage.py
+++ b/comfyui_skills_cli/storage.py
@@ -43,7 +43,10 @@ def list_workflows(base_dir: Path, server_id: str) -> list[dict[str, Any]]:
 
 
 def get_workflow_detail(base_dir: Path, server_id: str, workflow_id: str) -> dict[str, Any] | None:
-    workflow_dir = _safe_path(base_dir, server_id, workflow_id)
+    try:
+        workflow_dir = _safe_path(base_dir, server_id, workflow_id)
+    except ValueError:
+        return None
     if not workflow_dir.is_dir():
         return None
 
@@ -65,15 +68,20 @@ def get_workflow_detail(base_dir: Path, server_id: str, workflow_id: str) -> dic
 
 
 def get_workflow_data(base_dir: Path, server_id: str, workflow_id: str) -> dict[str, Any] | None:
-    path = _safe_path(base_dir, server_id, workflow_id) / "workflow.json"
+    try:
+        path = _safe_path(base_dir, server_id, workflow_id) / "workflow.json"
+    except ValueError:
+        return None
     if not path.exists():
         return None
     return _load_json(path)
 
 
 def get_schema(base_dir: Path, server_id: str, workflow_id: str) -> dict[str, Any] | None:
-    path = _safe_path(base_dir, server_id, workflow_id) / "schema.json"
-    if not path.exists():
+    try:
+        path = _safe_path(base_dir, server_id, workflow_id) / "schema.json"
+    except ValueError:
+        return None
         return None
     return _load_json(path)
 


### PR DESCRIPTION
Validate that resolved paths from server_id/workflow_id stay within the data directory. Reject inputs containing ../ or absolute paths.