### PR TITLE
refactor: remove non-essential commands per restraint principle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,9 @@
 
 - `nodes list / info / search` — discover available ComfyUI nodes, inspect input/output schemas, search by name or category
 - `server stats` — show VRAM, RAM, GPU, ComfyUI/Python/PyTorch versions (`--all` for multi-server comparison)
-- `server features` — query server capability flags
 - `jobs list / show` — server-side job history with status filtering and pagination
 - `logs show` — access ComfyUI server logs for error diagnosis
 - `templates list / subgraphs` — discover workflow templates and reusable subgraph components
-- `models embeddings` — list installed text embeddings
-- `models metadata` — inspect safetensors model metadata
 
 ### New Flags
 
@@ -29,4 +26,3 @@
 ### Fixes
 
 - Handle `None` values in `/object_info` category and display_name fields
-- Fix double error output in `models metadata` when file not found

--- a/README.ja.md
+++ b/README.ja.md
@@ -136,8 +136,6 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 | `comfyui-skill nodes search <query>` | 名前やカテゴリでノードを検索 |
 | `comfyui-skill models list` | 利用可能なモデルフォルダを一覧表示 |
 | `comfyui-skill models list <folder>` | 指定フォルダ内のモデルを一覧表示（例: `checkpoints`, `loras`） |
-| `comfyui-skill models embeddings` | 利用可能なテキスト埋め込みを一覧表示 |
-| `comfyui-skill models metadata <folder> <file>` | safetensorsモデルのメタデータを表示 |
 
 ### ワークフロー管理
 
@@ -159,7 +157,6 @@ comfyui-skill run txt2img -s my_server   # --server で上書き
 | `comfyui-skill server enable/disable <id>` | サーバーの有効/無効を切り替え |
 | `comfyui-skill server remove <id>` | サーバーを削除 |
 | `comfyui-skill server stats` | VRAM、RAM、GPU情報を表示（`--all`で全サーバー） |
-| `comfyui-skill server features` | サーバー機能フラグを表示 |
 
 ### 依存関係管理
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 | `comfyui-skill nodes search <query>` | Search nodes by name or category |
 | `comfyui-skill models list` | List all available model folders |
 | `comfyui-skill models list <folder>` | List models in a specific folder (e.g., `checkpoints`, `loras`) |
-| `comfyui-skill models embeddings` | List available text embeddings |
-| `comfyui-skill models metadata <folder> <file>` | Show safetensors model metadata |
 
 ### Workflow Management
 
@@ -159,7 +157,6 @@ comfyui-skill run txt2img -s my_server   # override with --server flag
 | `comfyui-skill server list` | List all configured servers |
 | `comfyui-skill server status` | Check if ComfyUI server is online |
 | `comfyui-skill server stats` | Show VRAM, RAM, GPU info (`--all` for multi-server) |
-| `comfyui-skill server features` | Show server capability flags |
 | `comfyui-skill server add --id <id> --url <url>` | Add a new server |
 | `comfyui-skill server enable/disable <id>` | Toggle server availability |
 | `comfyui-skill server remove <id>` | Remove a server |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -136,8 +136,6 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 | `comfyui-skill nodes search <query>` | 依名稱或分類搜尋節點 |
 | `comfyui-skill models list` | 列出所有可用模型資料夾 |
 | `comfyui-skill models list <folder>` | 列出指定資料夾中的模型（例如 `checkpoints`、`loras`） |
-| `comfyui-skill models embeddings` | 列出可用的文字嵌入 |
-| `comfyui-skill models metadata <folder> <file>` | 查看 safetensors 模型中繼資料 |
 
 ### 工作流程管理
 
@@ -159,7 +157,6 @@ comfyui-skill run txt2img -s my_server   # 透過 --server 覆寫
 | `comfyui-skill server enable/disable <id>` | 啟用或停用伺服器 |
 | `comfyui-skill server remove <id>` | 移除伺服器 |
 | `comfyui-skill server stats` | 查看 VRAM、RAM、GPU 資訊（`--all` 查看所有伺服器） |
-| `comfyui-skill server features` | 查看伺服器功能旗標 |
 
 ### 依賴管理
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -136,8 +136,6 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | `comfyui-skill nodes search <query>` | 按名称或分类搜索节点 |
 | `comfyui-skill models list` | 列出所有模型文件夹 |
 | `comfyui-skill models list <folder>` | 列出指定文件夹中的模型（如 `checkpoints`、`loras`） |
-| `comfyui-skill models embeddings` | 列出可用的文本嵌入 |
-| `comfyui-skill models metadata <folder> <file>` | 查看 safetensors 模型元数据 |
 
 ### 工作流管理
 
@@ -159,7 +157,6 @@ comfyui-skill run txt2img -s my_server   # 通过 --server 指定
 | `comfyui-skill server enable/disable <id>` | 启用/禁用服务器 |
 | `comfyui-skill server remove <id>` | 移除服务器 |
 | `comfyui-skill server stats` | 查看 VRAM、RAM、GPU 信息（`--all` 查看所有服务器） |
-| `comfyui-skill server features` | 查看服务器功能标志 |
 
 ### 依赖管理
 

--- a/comfyui_skills_cli/client.py
+++ b/comfyui_skills_cli/client.py
@@ -169,17 +169,6 @@ class ComfyUIClient:
         resp.raise_for_status()
         return resp.json()
 
-    def get_embeddings(self) -> list[str]:
-        resp = self._get("/embeddings")
-        resp.raise_for_status()
-        return resp.json()
-
-    def get_model_metadata(self, folder: str, filename: str) -> dict[str, Any]:
-        resp = self._get(f"/view_metadata/{folder}", params={"filename": filename})
-        if resp.status_code == 404:
-            return {}
-        resp.raise_for_status()
-        return resp.json()
 
     # -- Manager API (ComfyUI-Manager plugin) --
 
@@ -307,17 +296,10 @@ class ComfyUIClient:
         resp.raise_for_status()
         return resp.json()
 
-    # -- Node replacements, features, logs, templates --
+    # -- Node replacements, logs, templates --
 
     def get_node_replacements(self) -> dict[str, str]:
         resp = self._get("/node_replacements")
-        if resp.status_code == 404:
-            return {}
-        resp.raise_for_status()
-        return resp.json()
-
-    def get_features(self) -> dict[str, Any]:
-        resp = self._get("/features")
         if resp.status_code == 404:
             return {}
         resp.raise_for_status()

--- a/comfyui_skills_cli/commands/models.py
+++ b/comfyui_skills_cli/commands/models.py
@@ -40,33 +40,3 @@ def models_list(
         return
 
 
-@app.command("embeddings")
-def models_embeddings(ctx: typer.Context):
-    """List available text embeddings."""
-    client, server_id = build_client(ctx)
-    try:
-        embeddings = client.get_embeddings()
-        output_result(ctx, {"server_id": server_id, "embeddings": embeddings, "count": len(embeddings)})
-    except Exception as exc:
-        output_error(ctx, "EMBEDDINGS_FAILED", f"Failed to list embeddings: {exc}")
-        return
-
-
-@app.command("metadata")
-def models_metadata(
-    ctx: typer.Context,
-    folder: str = typer.Argument(help="Model folder (e.g., checkpoints, loras)"),
-    filename: str = typer.Argument(help="Model filename"),
-):
-    """Show safetensors metadata for a model file."""
-    client, server_id = build_client(ctx)
-    try:
-        data = client.get_model_metadata(folder, filename)
-    except Exception as exc:
-        output_error(ctx, "METADATA_FAILED", f"Failed to fetch metadata: {exc}")
-        return
-
-    if not data:
-        output_error(ctx, "NO_METADATA", f"No metadata found for {folder}/{filename}")
-        return
-    output_result(ctx, {"server_id": server_id, "folder": folder, "filename": filename, "metadata": data})

--- a/comfyui_skills_cli/commands/server.py
+++ b/comfyui_skills_cli/commands/server.py
@@ -207,33 +207,6 @@ def server_remove(
     output_result(ctx, {"server_id": server_id, "removed": True})
 
 
-@app.command("features")
-def server_features(
-    ctx: typer.Context,
-    server_id: str = typer.Argument("", help="Server ID (default: default server)"),
-):
-    """Show server feature flags and capabilities."""
-    base_dir = get_base_dir(ctx.obj.get("base_dir", ""))
-    config = load_config(base_dir)
-    sid = server_id or ctx.obj.get("server") or get_default_server_id(config)
-    server_config = get_server(config, sid)
-
-    if not server_config:
-        output_error(ctx, "SERVER_NOT_FOUND", f'Server "{sid}" not found.',
-                     hint="Run `comfy-skills server list` to see configured servers.")
-        return
-
-    client = ComfyUIClient(
-        server_url=server_config.get("url", "http://127.0.0.1:8188"),
-        auth=server_config.get("auth", ""),
-    )
-    try:
-        features = client.get_features()
-        output_result(ctx, {"server_id": sid, "features": features})
-    except Exception as exc:
-        output_error(ctx, "SERVER_ERROR", f"Failed to fetch features: {exc}")
-        return
-
 
 def _toggle_server(ctx: typer.Context, server_id: str, enabled: bool) -> None:
     base_dir = get_base_dir(ctx.obj.get("base_dir", ""))


### PR DESCRIPTION
Remove models metadata, models embeddings, and server features. These violate the restraint principle — they either have workarounds or expose internal info agents don't need.