### PR TITLE
feat: add --type video preset and fix media type inference

### DIFF
--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -399,12 +399,25 @@ def _inject_params(
     return workflow
 
 
-_MEDIA_KEYS: dict[str, str] = {
-    "images": "image",
-    "audio": "audio",
-    "gifs": "image",
-    "video": "video",
-}
+_MEDIA_KEYS = ("images", "audio")
+
+_VIDEO_EXTENSIONS = {".mp4", ".webm", ".mkv", ".avi", ".mov", ".gif"}
+_AUDIO_EXTENSIONS = {".mp3", ".wav", ".flac", ".ogg", ".aac", ".m4a"}
+
+
+def _infer_media_type(filename: str, fallback: str) -> str:
+    """Infer media type from file extension.
+
+    ComfyUI's SaveVideo/PreviewVideo nodes report video output under
+    the ``"images"`` history key, so relying on the key alone would
+    misclassify video files as images.
+    """
+    ext = Path(filename).suffix.lower()
+    if ext in _VIDEO_EXTENSIONS:
+        return "video"
+    if ext in _AUDIO_EXTENSIONS:
+        return "audio"
+    return fallback
 
 
 def _collect_outputs(outputs: dict[str, Any]) -> list[dict[str, str]]:
@@ -412,13 +425,15 @@ def _collect_outputs(outputs: dict[str, Any]) -> list[dict[str, str]]:
     for node_output in outputs.values():
         if not isinstance(node_output, dict):
             continue
-        for key, media_type in _MEDIA_KEYS.items():
+        for key in _MEDIA_KEYS:
+            fallback = "audio" if key == "audio" else "image"
             for item in node_output.get(key, []):
+                filename = item.get("filename", "")
                 collected.append({
-                    "filename": item.get("filename", ""),
+                    "filename": filename,
                     "subfolder": item.get("subfolder", ""),
                     "type": item.get("type", "output"),
-                    "media_type": media_type,
+                    "media_type": _infer_media_type(filename, fallback),
                 })
     return collected
 

--- a/comfyui_skills_cli/commands/workflow.py
+++ b/comfyui_skills_cli/commands/workflow.py
@@ -70,6 +70,14 @@ _MEDIA_TYPE_FIELDS: dict[str, dict[str, dict[str, Any]]] = {
         "cfg_scale": {"exposed": True, "required": False, "description": "Classifier-free guidance scale"},
         "temperature": {"exposed": True, "required": False, "description": "Sampling temperature"},
     },
+    "video": {
+        "format": {"exposed": True, "required": False, "description": "Output video format"},
+        "codec": {"exposed": True, "required": False, "description": "Video codec"},
+        "frame_rate": {"exposed": True, "required": False, "description": "Video frame rate"},
+        "fps": {"exposed": True, "required": False, "description": "Frames per second"},
+        "noise_seed": {"exposed": True, "required": False, "description": "Noise seed for video generation"},
+        "cfg": {"exposed": True, "required": False, "description": "Classifier-free guidance scale"},
+    },
 }
 
 _LOAD_IMAGE_CLASSES = {"LoadImage", "LoadImageMask"}
@@ -91,6 +99,7 @@ def _extract_schema(workflow_data: dict[str, Any], media_type: str = "image") ->
     *media_type* selects additional field-exposure rules beyond the base
     set.  ``"image"`` (default) uses only the generic rules.
     ``"audio"`` adds audio-specific fields like tags, lyrics, bpm, etc.
+    ``"video"`` adds video-specific fields like format, codec, fps, etc.
     """
     expose_fields = dict(_AUTO_EXPOSE_FIELDS)
     if media_type in _MEDIA_TYPE_FIELDS:
@@ -384,7 +393,7 @@ def workflow_import(
     ctx: typer.Context,
     json_path: str = typer.Argument(None, help="Path to workflow JSON file (omit when using --from-server)"),
     name: str = typer.Option("", "--name", "-n", help="Workflow ID (default: derived from filename)"),
-    media_type: str = typer.Option("image", "--type", "-t", help="Media type preset for parameter detection: image (default), audio"),
+    media_type: str = typer.Option("image", "--type", "-t", help="Media type preset for parameter detection: image (default), audio, video"),
     from_server: bool = typer.Option(False, "--from-server", help="Import from ComfyUI server userdata"),
     preview: bool = typer.Option(False, "--preview", help="Preview only, don't import"),
     check_deps: bool = typer.Option(False, "--check-deps", help="Check dependencies after import"),


### PR DESCRIPTION
## Summary

- **Fix media type misclassification**: ComfyUI's `SaveVideo`/`PreviewVideo` nodes report video output under the `"images"` history key, causing all video files to be reported as `media_type: "image"`. Now uses file extension (`.mp4`, `.webm`, `.mp3`, `.wav`, etc.) for accurate inference.
- **Remove dead code**: `"gifs"` and `"video"` entries in `_MEDIA_KEYS` never matched anything in ComfyUI's `/history` output (only `"images"` and `"audio"` are populated).
- **Add `--type video` preset**: Exposes video-specific fields (`format`, `codec`, `frame_rate`, `fps`, `noise_seed`, `cfg`) during `workflow import`. Follows the trimming guidance from PR #4 review — only fields truly characteristic of video workflows are included.

Inspired by @av1155's investigation in #4.

## Test plan

- [x] 49 existing tests pass
- [ ] Import a video workflow with `--type video` and verify extra fields are exposed
- [ ] Run a video workflow and verify output reports `media_type: "video"` (not `"image"`)
- [ ] Run an audio workflow and verify `media_type: "audio"` is unchanged
- [ ] Run an image workflow and verify `media_type: "image"` is unchanged
