### PR TITLE
chore: bump version to 0.2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=61"]
 
 [project]
 name = "comfyui-skill-cli"
-version = "0.2.7"
+version = "0.2.8"
 description = "ComfyUI Skill CLI — Agent-friendly workflow management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version to 0.2.8 for PyPI release
- Includes: video media type inference fix, `--type video` preset, Korean/Spanish READMEs
