### PR TITLE
fix: workflow import --from-server on ComfyUI 0.19.0

### DIFF
--- a/comfyui_skills_cli/client.py
+++ b/comfyui_skills_cli/client.py
@@ -327,33 +327,54 @@ class ComfyUIClient:
     # -- ComfyUI Userdata API --
 
     def list_userdata_workflows(self) -> list[str]:
-        for path in ["/v2/userdata", "/userdata"]:
+        # /v2/userdata uses "path" (not "dir") and returns a list of dicts
+        # with a "path" key. /userdata uses "dir" and returns bare filenames.
+        # Skip empty results so a working variant is always found.
+        candidates = [
+            ("/v2/userdata", {"path": "workflows"}),
+            ("/userdata", {"dir": "workflows"}),
+        ]
+        for base, params in candidates:
             try:
-                resp = self._get(f"{path}?dir=workflows&recurse=true")
-                if resp.status_code == 200:
-                    data = resp.json()
-                    if isinstance(data, list):
-                        return [f for f in data if isinstance(f, str) and f.endswith(".json")]
-                    if isinstance(data, dict) and "files" in data:
-                        return [
-                            f.get("path", f.get("name", ""))
-                            for f in data["files"]
-                            if isinstance(f, dict) and (f.get("path", "") or f.get("name", "")).endswith(".json")
-                        ]
+                resp = self._get(base, params=params)
+                if resp.status_code != 200:
+                    continue
+                data = resp.json()
+                paths: list[str] = []
+                if isinstance(data, list):
+                    for item in data:
+                        if isinstance(item, str) and item.endswith(".json"):
+                            # /userdata?dir= returns bare filenames; normalise
+                            # to a full relative path for read_userdata_workflow.
+                            paths.append(item if "/" in item else f"workflows/{item}")
+                        elif isinstance(item, dict):
+                            p = item.get("path") or item.get("name") or ""
+                            if isinstance(p, str) and p.endswith(".json"):
+                                paths.append(p)
+                elif isinstance(data, dict) and "files" in data:
+                    paths = [
+                        f.get("path", f.get("name", ""))
+                        for f in data["files"]
+                        if isinstance(f, dict) and (f.get("path", "") or f.get("name", "")).endswith(".json")
+                    ]
+                if paths:
+                    return paths
             except (requests.RequestException, ValueError):
                 continue
         return []
 
     def read_userdata_workflow(self, workflow_path: str) -> dict[str, Any] | None:
         import urllib.parse
+        # aiohttp matches /userdata/{file} as a single path segment. Percent-
+        # encode the full relative path (including "/" separators) so it is
+        # not split into multiple segments, which would return 404.
         encoded = urllib.parse.quote(workflow_path, safe="")
-        for base in ["/v2/userdata", "/userdata"]:
-            try:
-                resp = self._get(f"{base}/workflows/{encoded}")
-                if resp.status_code == 200:
-                    return resp.json()
-            except (requests.RequestException, ValueError):
-                continue
+        try:
+            resp = self._get(f"/userdata/{encoded}")
+            if resp.status_code == 200:
+                return resp.json()
+        except (requests.RequestException, ValueError):
+            pass
         return None
 
     # -- Manager model install --

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -275,5 +275,71 @@ class WsEventsTests(unittest.TestCase):
         self.assertEqual(collected[0]["type"], "execution_error")
 
 
+# -- userdata workflows --
+
+class ListUserdataWorkflowsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_v2_userdata_returns_list_of_dicts(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: [
+                {"name": "a.json", "path": "workflows/a.json", "type": "file"},
+                {"name": "b.json", "path": "workflows/b.json", "type": "file"},
+            ],
+        )
+        paths = self.client.list_userdata_workflows()
+        self.assertEqual(paths, ["workflows/a.json", "workflows/b.json"])
+        self.assertEqual(mock_get.call_args.kwargs["params"], {"path": "workflows"})
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_falls_back_to_userdata_bare_strings(self, mock_get: MagicMock) -> None:
+        # /v2/userdata returns empty, /userdata returns bare filenames
+        mock_get.side_effect = [
+            MagicMock(status_code=200, json=lambda: []),
+            MagicMock(status_code=200, json=lambda: ["a.json", "b.json"]),
+        ]
+        paths = self.client.list_userdata_workflows()
+        self.assertEqual(paths, ["workflows/a.json", "workflows/b.json"])
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_both_endpoints_empty(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: [])
+        self.assertEqual(self.client.list_userdata_workflows(), [])
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_filters_non_json_entries(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: [
+                {"path": "workflows/a.json"},
+                {"path": "comfy.settings.json"},
+                {"path": "workflows/readme.txt"},
+            ],
+        )
+        paths = self.client.list_userdata_workflows()
+        self.assertEqual(paths, ["workflows/a.json", "comfy.settings.json"])
+
+
+class ReadUserdataWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ComfyUIClient("http://localhost:8188")
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_percent_encodes_full_path(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"nodes": []})
+        self.client.read_userdata_workflow("workflows/MultiCharacter.json")
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("/userdata/workflows%2FMultiCharacter.json", called_url)
+        self.assertNotIn("/userdata/workflows/MultiCharacter.json", called_url)
+
+    @patch("comfyui_skills_cli.client.requests.get")
+    def test_returns_none_on_404(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = MagicMock(status_code=404)
+        self.assertIsNone(self.client.read_userdata_workflow("workflows/missing.json"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #28 — `workflow import --from-server` was silently broken on ComfyUI 0.19.0, always returning `NO_WORKFLOWS`.

Two independent bugs in `comfyui_skills_cli/client.py`:

### Bug 1 — `list_userdata_workflows()`
- `/v2/userdata` uses `path` (not `dir`) and returns a **list of dicts** with a `"path"` key on ComfyUI 0.19.0
- Previous code only handled list-of-strings, silently returning `[]` and never falling back to `/userdata?dir=workflows`
- Fix: handle dict items, use `params=` kwarg, skip empty responses to allow real fallback
- All results are normalised to full relative paths (e.g. `workflows/foo.json`) so the read function doesn't need to guess

### Bug 2 — `read_userdata_workflow()`
- aiohttp's `/userdata/{file}` route matches only a single path segment — the hardcoded `/` between `workflows` and the filename returned 404
- Fix: percent-encode the full relative path including `/` separators → `/userdata/workflows%2Ffoo.json`

Both bugs are independent: even with bug 1 fixed, bug 2 would still cause every file read to fail.

## Credit

All analysis, root-cause identification, and the patch itself are from @DanielBoettner's high-quality report in #28. HTTP traces and the Option A/B/C tradeoff analysis there are worth reading.

## Test plan

- [x] 6 new unit tests added, all 55 tests pass
  - `list_userdata_workflows`: v2 list-of-dicts, fallback to bare strings, both empty, filters non-JSON
  - `read_userdata_workflow`: verifies `/userdata/workflows%2Ffoo.json` URL encoding, 404 returns None
- [ ] Manual verification on ComfyUI 0.19.0: `workflow import --from-server` successfully imports workflows (confirmed by reporter in #28)
