### PR TITLE
feat: auto-upload local image paths before running workflow

### DIFF
--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -48,6 +48,7 @@ def run_cmd(
 
     input_args = _parse_args(ctx, args)
     parameters = _get_parameters(schema_data)
+    _upload_media(ctx, client, parameters, input_args)
     workflow = _inject_params(workflow_data, parameters, input_args)
 
     client_id = str(uuid.uuid4())
@@ -266,6 +267,7 @@ def submit_cmd(
 
     input_args = _parse_args(ctx, args)
     parameters = _get_parameters(schema_data)
+    _upload_media(ctx, client, parameters, input_args)
     workflow = _inject_params(workflow_data, parameters, input_args)
     targets = [t.strip() for t in only.split(",") if t.strip()] if only else None
 
@@ -381,6 +383,47 @@ def _get_parameters(schema_data: dict[str, Any]) -> dict[str, Any]:
             if name not in parameters and ui_param.get("exposed", False):
                 parameters[name] = ui_param
     return parameters
+
+
+def _looks_like_local_path(value: str) -> bool:
+    """Only treat explicit filesystem paths as upload candidates.
+
+    Bare filenames (``cat.png``) and server subfolder refs (``clipspace/foo.png``)
+    are resolved on the ComfyUI server and must not be replaced by whatever
+    happens to sit in the caller's cwd.
+    """
+    return os.path.isabs(value) or value.startswith(("./", "../", "~"))
+
+
+def _upload_media(
+    ctx: typer.Context,
+    client: ComfyUIClient,
+    parameters: dict[str, Any],
+    args: dict[str, Any],
+) -> None:
+    """Upload local image files referenced by image-type params to ComfyUI.
+
+    Rewrites ``args`` in place: an explicit local file path becomes the uploaded
+    reference (``subfolder/name`` or ``name``) that ``LoadImage`` expects.
+    URLs, bare filenames, server-side subfolder refs, and non-existent paths
+    are left untouched.
+    """
+    for key, value in list(args.items()):
+        if parameters.get(key, {}).get("type") != "image":
+            continue
+        if not isinstance(value, str) or not _looks_like_local_path(value):
+            continue
+        expanded = os.path.expanduser(value)
+        if not os.path.isfile(expanded):
+            continue
+        try:
+            result = client.upload_image(expanded)
+        except Exception as exc:
+            output_error(ctx, "UPLOAD_FAILED", f"Failed to upload {value}: {exc}")
+            return
+        name = result.get("name", "")
+        subfolder = result.get("subfolder", "")
+        args[key] = f"{subfolder}/{name}" if subfolder else name
 
 
 def _inject_params(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,111 @@
+"""Tests for comfyui_skills_cli.commands.run helpers."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import typer
+
+from comfyui_skills_cli.commands.run import _upload_media
+
+
+def _ctx() -> typer.Context:
+    ctx = MagicMock(spec=typer.Context)
+    ctx.obj = {"output_format": "json"}
+    return ctx
+
+
+class UploadMediaTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ctx = _ctx()
+        self.client = MagicMock()
+
+    def test_rewrites_local_image_path_without_subfolder(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".png") as f:
+            self.client.upload_image.return_value = {"name": "uploaded.png", "subfolder": "", "type": "input"}
+            parameters = {"image": {"type": "image"}}
+            args = {"image": f.name}
+            _upload_media(self.ctx, self.client, parameters, args)
+            self.client.upload_image.assert_called_once_with(f.name)
+            self.assertEqual(args["image"], "uploaded.png")
+
+    def test_rewrites_local_image_path_with_subfolder(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".png") as f:
+            self.client.upload_image.return_value = {"name": "uploaded.png", "subfolder": "clipspace", "type": "input"}
+            parameters = {"image": {"type": "image"}}
+            args = {"image": f.name}
+            _upload_media(self.ctx, self.client, parameters, args)
+            self.assertEqual(args["image"], "clipspace/uploaded.png")
+
+    def test_skips_non_existent_path(self) -> None:
+        parameters = {"image": {"type": "image"}}
+        args = {"image": "/nonexistent/path/to/image.png"}
+        _upload_media(self.ctx, self.client, parameters, args)
+        self.client.upload_image.assert_not_called()
+        self.assertEqual(args["image"], "/nonexistent/path/to/image.png")
+
+    def test_skips_bare_filename(self) -> None:
+        parameters = {"image": {"type": "image"}}
+        args = {"image": "already_on_server.png"}
+        _upload_media(self.ctx, self.client, parameters, args)
+        self.client.upload_image.assert_not_called()
+        self.assertEqual(args["image"], "already_on_server.png")
+
+    def test_skips_url(self) -> None:
+        parameters = {"image": {"type": "image"}}
+        args = {"image": "https://example.com/cat.png"}
+        _upload_media(self.ctx, self.client, parameters, args)
+        self.client.upload_image.assert_not_called()
+        self.assertEqual(args["image"], "https://example.com/cat.png")
+
+    def test_skips_non_image_param(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".png") as f:
+            parameters = {"seed": {"type": "int"}}
+            args = {"seed": f.name}
+            _upload_media(self.ctx, self.client, parameters, args)
+            self.client.upload_image.assert_not_called()
+            self.assertEqual(args["seed"], f.name)
+
+    def test_upload_failure_raises_typer_exit(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".png") as f:
+            self.client.upload_image.side_effect = RuntimeError("server is down")
+            parameters = {"image": {"type": "image"}}
+            args = {"image": f.name}
+            with self.assertRaises(typer.Exit):
+                _upload_media(self.ctx, self.client, parameters, args)
+
+    def test_skips_bare_filename_even_when_file_exists_in_cwd(self) -> None:
+        # Regression: a bare filename must resolve on the ComfyUI server,
+        # never on the caller's cwd. Otherwise `run` becomes cwd-dependent.
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "cat.png").touch()
+            original_cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                parameters = {"image": {"type": "image"}}
+                args = {"image": "cat.png"}
+                _upload_media(self.ctx, self.client, parameters, args)
+                self.client.upload_image.assert_not_called()
+                self.assertEqual(args["image"], "cat.png")
+            finally:
+                os.chdir(original_cwd)
+
+    def test_expands_tilde_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            test_file = Path(tmp) / "cat.png"
+            test_file.touch()
+            self.client.upload_image.return_value = {"name": "cat.png", "subfolder": "", "type": "input"}
+            with patch.dict(os.environ, {"HOME": tmp}):
+                parameters = {"image": {"type": "image"}}
+                args = {"image": "~/cat.png"}
+                _upload_media(self.ctx, self.client, parameters, args)
+                self.client.upload_image.assert_called_once_with(str(test_file))
+                self.assertEqual(args["image"], "cat.png")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the case where `comfyui-skill run <skill> --args '{"image": "/local/path.png"}'` would fail with an obscure 400 — ComfyUI's `LoadImage` node expects a filename already in its input directory, not a local path.

Adds a `_upload_media()` step before `_inject_params` in both `run_cmd` and `submit_cmd`:

- Detects image-type params (the schema tags `LoadImage` / `LoadImageMask` fields as `type: "image"`)
- Auto-uploads only when the value **looks like an explicit filesystem path**: absolute, `./`, `../`, or `~/...`. Bare filenames (`cat.png`) and server subfolder refs (`clipspace/foo.png`) resolve on the ComfyUI server and are left alone — otherwise `run` would silently pick up whatever sits in the caller's `cwd` and override server-side files.
- Expands `~` before the file-existence check so home-relative paths work out of the box
- Uploads via `client.upload_image()` and rewrites the arg value to the returned reference
- Handles non-empty `subfolder` correctly: `subfolder/name` vs plain `name` (needed for `clipspace`)
- On upload failure: hard error via `output_error("UPLOAD_FAILED", ...)` rather than submitting with a broken path

## Credit

Approach, ordering (`_inject_params → upload → queue_prompt`), and the `UPLOAD_FAILED` error semantics come from @davidjoshua7692-code's work in #11. The `subfolder` handling (the one must-fix that remained open there), the cwd-safety heuristic, and `~` expansion are added here.

## Test plan

- [x] 9 unit tests in `tests/test_run.py`:
  - Local path + no subfolder → rewritten to `name`
  - Local path + subfolder response → rewritten to `subfolder/name`
  - Non-existent path → skipped, unchanged
  - Bare filename → skipped
  - URL → skipped
  - Non-image param type → skipped
  - Upload failure → raises `typer.Exit`
  - **Bare filename + file exists in cwd → skipped** (regression guard for cwd-dependent behavior)
  - **`~/path/file.png` → expanded and uploaded**
- [x] All 64 tests pass (55 existing + 9 new)
- [ ] Manual smoke test on ComfyUI: `run` with a local `.png` path succeeds

## Not in this PR

A separate bug (`status_cmd` doesn't download outputs after the job completes) was also caught by @davidjoshua7692-code in #11. Splitting that into its own PR to keep changes focused.
