### PR TITLE
fix: status_cmd now downloads output files to local disk

### DIFF
--- a/comfyui_skills_cli/commands/run.py
+++ b/comfyui_skills_cli/commands/run.py
@@ -305,6 +305,7 @@ def status_cmd(
         outputs = history.get("outputs", {})
         if status_info.get("completed", False) or outputs:
             collected = _collect_outputs(outputs)
+            collected = _download_outputs(client, collected, base_dir, server_config)
             output_result(ctx, {"status": "success", "prompt_id": prompt_id, "outputs": collected})
             return
         if status_info.get("status_str") == "error":


### PR DESCRIPTION
## Summary

When a workflow runs via `submit` + `status` (the async flow), the completion path built the output metadata list but never actually downloaded the files. Users got filenames back in the response but no files on disk.

One-line fix in `status_cmd`: call `_download_outputs()` after `_collect_outputs()`, mirroring the pattern already used by `_run_with_ws` (sync WebSocket path) and `_run_with_poll` (sync polling path).

```diff
 collected = _collect_outputs(outputs)
+collected = _download_outputs(client, collected, base_dir, server_config)
 output_result(ctx, {"status": "success", "prompt_id": prompt_id, "outputs": collected})
```

## Credit

Caught by @davidjoshua7692-code in #11 as a bonus finding alongside the local-image-upload work (#31).

## Test plan

- [x] 64 existing unit tests still pass
- [x] E2E smoke test against ComfyUI 0.19.0: `submit` a `LoadImage → SaveImage` workflow, wait for completion, run the fixed code path, and verify the PNG is written to disk. 11 KB file appeared at the expected path.

No new unit test: `status_cmd` is a CLI command composing load_config / _build_client / multiple helpers. A mock-heavy unit test would be larger than the fix itself and wouldn't catch more than the smoke test already did.
