### PR TITLE
fix: add COMBO to _WIDGET_BASE_TYPES for string-format COMBO inputs

### DIFF
--- a/comfyui_skills_cli/commands/workflow.py
+++ b/comfyui_skills_cli/commands/workflow.py
@@ -82,7 +82,7 @@ _MEDIA_TYPE_FIELDS: dict[str, dict[str, dict[str, Any]]] = {
 
 _LOAD_IMAGE_CLASSES = {"LoadImage", "LoadImageMask"}
 
-_WIDGET_BASE_TYPES = {"INT", "FLOAT", "STRING", "BOOLEAN"}
+_WIDGET_BASE_TYPES = {"INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"}
 
 
 def _is_widget_type(type_def: list) -> bool:


### PR DESCRIPTION
ComfyUI represents COMBO (dropdown) inputs in two formats:
- List format: [['optA','optB'], {}]  — handled correctly
- String format: ['COMBO', {'tooltip': ...}]  — was NOT matched

The string format is used by third-party nodes. Because 'COMBO' was absent from _WIDGET_BASE_TYPES, _is_widget_type() returned False for these nodes, causing their dropdown values to be skipped during widgets_values index alignment and producing an off-by-one error for all subsequent parameters in the same node.