### PR TITLE
test: cover string-format COMBO inputs in _convert_node_inputs

### DIFF
--- a/tests/test_workflow_convert_node_inputs.py
+++ b/tests/test_workflow_convert_node_inputs.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import unittest
 from typing import Any
 
-from comfyui_skills_cli.commands.workflow import _convert_node_inputs
+from comfyui_skills_cli.commands.workflow import _convert_node_inputs, _is_widget_type
 
 
 # Schema for EmptyFlux2LatentImage as ComfyUI's /object_info reports it.
@@ -201,6 +201,75 @@ class ConvertNodeInputsEdgeCaseTests(unittest.TestCase):
                 "batch_size": ["upstream", 0],
             },
         )
+
+
+class ConvertNodeInputsStringComboTests(unittest.TestCase):
+    """ComfyUI represents COMBO dropdown inputs in two formats:
+
+      * **List form** — ``[["optA", "optB"], {...}]``. Used by built-in nodes.
+      * **String form** — ``["COMBO", {"tooltip": "..."}]``. Used by third-party
+        nodes and ComfyUI's v2 IO system.
+
+    Both must be recognized as widget types. If string-form COMBO inputs are
+    skipped, every subsequent widget in the same node shifts left by one in
+    ``widgets_values``, silently corrupting parameters."""
+
+    def test_is_widget_type_recognizes_string_combo(self) -> None:
+        self.assertTrue(_is_widget_type(["COMBO", {"tooltip": "Choose preset"}]))
+
+    def test_is_widget_type_still_recognizes_list_combo(self) -> None:
+        self.assertTrue(_is_widget_type([["euler", "euler_ancestral", "dpmpp_2m"]]))
+
+    def test_third_party_node_with_string_combo_aligns_correctly(self) -> None:
+        """Schema uses string-form COMBO followed by FLOAT and INT widgets.
+
+        Without the fix, ``preset`` would be skipped and ``strength``/``seed``
+        would consume the wrong widgets_values entries.
+        """
+        node_info = {
+            "input_order": {"required": ["preset", "strength", "seed"]},
+            "input": {
+                "required": {
+                    "preset": ["COMBO", {"tooltip": "Choose preset", "options": ["A", "B", "C"]}],
+                    "strength": ["FLOAT", {"default": 1.0}],
+                    "seed": ["INT", {"default": 0}],
+                }
+            },
+        }
+        node = {
+            "id": 99,
+            "type": "ThirdPartyNode",
+            "inputs": [],
+            "widgets_values": ["B", 0.8, 42],
+        }
+
+        out = _convert_node_inputs(node, node["type"], node_info, {})
+
+        self.assertEqual(out, {"preset": "B", "strength": 0.8, "seed": 42})
+
+    def test_node_mixing_string_and_list_combo(self) -> None:
+        """A single node may mix both COMBO representations. Both should be
+        treated as widget types and consume widgets_values entries in order."""
+        node_info = {
+            "input_order": {"required": ["preset", "sampler", "steps"]},
+            "input": {
+                "required": {
+                    "preset": ["COMBO", {"tooltip": "string form"}],
+                    "sampler": [["euler", "dpmpp_2m"]],  # list form
+                    "steps": ["INT", {"default": 20}],
+                }
+            },
+        }
+        node = {
+            "id": 100,
+            "type": "MixedComboNode",
+            "inputs": [],
+            "widgets_values": ["A", "euler", 25],
+        }
+
+        out = _convert_node_inputs(node, node["type"], node_info, {})
+
+        self.assertEqual(out, {"preset": "A", "sampler": "euler", "steps": 25})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the test coverage gap that allowed #38's bug to slip past #37. ComfyUI exposes COMBO dropdown inputs in two interchangeable schema formats:

* **List form** — `[["optA", "optB"], {...}]` (built-in nodes)
* **String form** — `["COMBO", {"tooltip": "..."}]` (third-party nodes, ComfyUI v2 IO)

The regression suite from #37 only exercised the list form. The string form went silently broken until #38 surfaced it. This PR adds four targeted cases:

| Test | What it pins |
|---|---|
| `test_is_widget_type_recognizes_string_combo` | Unit: `_is_widget_type(["COMBO", {...}])` returns `True` |
| `test_is_widget_type_still_recognizes_list_combo` | Unit: list-form COMBO keeps working (guards against future overcorrection) |
| `test_third_party_node_with_string_combo_aligns_correctly` | End-to-end: schema starts with a string-COMBO, followed by FLOAT/INT widgets — `widgets_values` must not shift |
| `test_node_mixing_string_and_list_combo` | Mixed-form node: string COMBO + list COMBO + INT all in one schema, all three values must land in correct fields |

All four pass against `main` post-#38.

## Why both forms matter

A node like `preset: ["COMBO", {...}]` followed by `strength: ["FLOAT", ...]` and `seed: ["INT", ...]` with `widgets_values: ["B", 0.8, 42]` would, pre-#38, produce `{strength: "B", seed: 0.8}` — `preset` was silently dropped and every downstream widget shifted left by one. Easy to miss because numbers still "look like numbers" in the JSON.

## Test plan

- [x] `python -m unittest tests.test_workflow_convert_node_inputs -v` — all 8 cases pass
- [x] Confirmed no diff to non-test source files
